### PR TITLE
Fastswitch loadouts + GB idle general fix

### DIFF
--- a/Chrome/unpacked/js/caap_passivegeneral.js
+++ b/Chrome/unpacked/js/caap_passivegeneral.js
@@ -20,8 +20,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				con.log(5,"Idle Check paused",timedLoadoutCheck);
 				return timedLoadoutCheck === 'change';
 			}
-			con.log(5,"Idle Check equipped",timedLoadoutCheck);
-			return caap.stats.battleIdle ? general.Select('GFightGeneral') : general.Select('IdleGeneral');
+			con.log(5,"Idle Check equipped",timedLoadoutCheck, caap.stats.battleIdle, general.Select('GFightGeneral'));
+			return caap.stats.battleIdle ? general.Select(caap.stats.battleIdle) : general.Select('IdleGeneral');
         } catch (err) {
             con.error("ERROR in passiveGeneral: " + err);
             return false;

--- a/Chrome/unpacked/js/general.js
+++ b/Chrome/unpacked/js/general.js
@@ -189,7 +189,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             }
 
 			if (!quiet) {
-				con.warn("Unable to find 'General' record", generalName);
+				con.warn("GetRecord: Unable to find 'General' record", generalName);
 			}
 
 			return false;
@@ -427,7 +427,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 temptext = '';
 
             if (generalName === 'Use Current' || !generalRecord) {
-                con.warn("Unable to find 'General' record", generalName);
+                con.warn("Get Equipped Stats: Unable to find 'General' record", generalName);
                 return false;
             }
 
@@ -937,10 +937,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				}
 				con.log(2,'Loading ' +targetLoadout + ' value ' + lRecord.value, lRecord);
 
-				// Although loadout fast switch possible, do loadout switch on generals page to capture stats.
-				if (caap.navigateTo('mercenary,generals', 'tab_generals_on.gif')) {
-					return true;
-				}
 				general.clickedLoadout = lRecord.value-1;
 				caap.click($j('div[id*="hot_swap_loadouts_content_div"] > div:nth-child(' + lRecord.value + ') > div:first'));
 				return true;
@@ -1004,6 +1000,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					((caap.stats.stamina.max || 0) > 0 && caap.stats.stamina.num > caap.stats.stamina.max *.7)) {
 					con.log(4, "Delaying general stats review while high sta/ene ", caap.stats.energy.max, caap.stats.energy.num, caap.stats.stamina.max, caap.stats.stamina.num);
 					return false;
+				}
+				if (session.getItem("page", "") != 'generals') {
+					caap.navigateTo('mercenary,generals', 'tab_generals_on.gif');
 				}
 				if (general.selectSpecific(general.records[it].name)) {
 					con.log(2, "Loading general #" + (it + 1) + ' of ' + (len + 1), general.records[it].name);

--- a/Chrome/unpacked/js/guild_battle.js
+++ b/Chrome/unpacked/js/guild_battle.js
@@ -1092,7 +1092,6 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 			} else {
 				caap.stats.battleIdle = false;
 			}
-			con.log(5,'1', gf.page);
 
 			// Work around for faulty storage of caap.stats
 			if (caap.stats.indicators.api == 0) {
@@ -1102,6 +1101,9 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
             for (i = 0; i < caap.stats.reviewPagesGB.length; i++) {
                 if (caap.stats.reviewPagesGB[i].path.indexOf(gf.page) >= 0 && schedule.since(caap.stats.reviewPagesGB[i].review, 5 * 60)) {
 					con.log(5,'Reviewing battle page',caap.stats.reviewPagesGB[i].path, caap.stats.reviewPagesGB);
+					if (caap.stats.battleIdle && general.Select(caap.stats.battleIdle)) {
+						return true;
+					}
 					result = caap.navigate2(caap.stats.reviewPagesGB[i].path);
 					if (result == 'fail') {
 						guild_battle.deleterPage('path', caap.stats.reviewPagesGB[i].path);


### PR DESCRIPTION
Enabled fast switching for loadouts instead of going to generals page
Fixed bug that prevented equipping idle battle general
Added in equipping of idle general when reviewing GB towers
