### PR TITLE
Battle fix

### DIFF
--- a/Chrome/unpacked/js/battle.js
+++ b/Chrome/unpacked/js/battle.js
@@ -298,7 +298,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
     };
 
     battle.flagResult = false;
-
+	
+	// Check win/loss of battle
     battle.getResult = function() {
         try {
             var tempDiv = $j(),
@@ -555,6 +556,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
+	// Check if target is dead
     battle.deadCheck = function() {
         try {
             var battleRecord = {},
@@ -846,11 +848,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 firstId = '',
                 lastBattleID = 0,
                 engageButton = $j(),
-                time = 0,
                 found = 0,
                 entryLimit = 0,
-                noSafeCount = 0,
-                noSafeCountSet = 0;
+                noSafeCount = 0;
 
             if (!$u.hasContent(inputDiv)) {
                 con.warn('Not on battlepage');
@@ -935,11 +935,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     len = 0,
                     tempRecord = type === "recon" ? new battle.reconRecord() : new battle.record();
 
-                tempRecord.data.button = $j(this);
                 if (type === 'Raid') {
                     tr = tempRecord.data.button.parents().eq(4);
                 } else {
-                    tr = tempRecord.data.button.parents("tr").eq(0);
+					tempRecord.data.button = $j(this);
+                    tr = tempRecord.data.button.closest('div[style*="battle_mid.jpg"]');
                 }
 
                 inp = $j("input[name='target_id']", tr);
@@ -1090,6 +1090,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                         tempRecord.data.armyNum = $u.setContent(levelm[5], '').parseInt();
                     }
                 }
+				
+				con.log(2, 'Battle target stats:', tempRecord.data.nameStr, tempRecord.data.levelNum, tempRecord.data.rankStr, tempRecord.data.rankNum, tempRecord.data.armyNum);
 
                 if (battle.hashCheck(tempRecord.data)) {
                     inputDiv = null;
@@ -1437,15 +1439,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             }
 
             noSafeCount = state.setItem("notSafeCount", state.getItem("notSafeCount", 0) + 1);
-            noSafeCountSet = config.getItem("notSafeCount", 20);
-            noSafeCountSet = noSafeCountSet < 1 ? 1 : noSafeCountSet;
-            if (noSafeCount >= noSafeCountSet) {
+            if (noSafeCount >= 2) {
                 caap.setDivContent('battle_mess', 'Leaving Battle. Will Return Soon.');
                 con.log(1, 'No safe targets limit reached. Releasing control for other processes: ', noSafeCount);
                 state.setItem("notSafeCount", 0);
-                time = config.getItem("NoTargetDelay", 45);
-                time = time < 10 ? 10 : time;
-                schedule.setItem("NoTargetDelay", time);
+                schedule.setItem("NoTargetDelay", 60);
                 inputDiv = null;
                 inp = null;
                 form = null;
@@ -1574,11 +1572,6 @@ config.setItem('raidDoSiege', false)
             htmlCode += caap.makeTextBox('BattleTargets', userIdInstructions, '');
             htmlCode += caap.endDropHide('TargetType', 'UserId');
             htmlCode += caap.endDropHide('WhenBattle');
-            htmlCode += caap.makeCheckTR("Modify Timers", 'battleModifyTimers', false, "Advanced timers for how often Battle functions are performed.");
-            htmlCode += caap.startCheckHide('battleModifyTimers');
-            htmlCode += caap.makeNumberFormTR("Battle retry", 'notSafeCount', "Check the Battle/Raid X times before release and delay for other processes. Minimum 1.", 20, '', '', true);
-            htmlCode += caap.makeNumberFormTR("Battle delay", 'NoTargetDelay', "Check the Battle/Raid every X seconds when no target available. Minimum 10.", 45, '', '', true);
-            htmlCode += caap.endCheckHide('battleModifyTimers');
             htmlCode += caap.endToggle;
             return htmlCode;
         } catch (err) {

--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -1582,10 +1582,10 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				});
 			}
 
-			if (caap.hyper && hyper.getItem('logons', false) && hyper.getItem('logons', false).length > 1) {
+			if (typeof hyper == 'defined' && $u.isArray(hyper.getItem('logons', false)) && hyper.getItem('logons', false).length > 1) {
 				caap.hyper = true;
 				schedule.setItem("hyperTimer", 0);
-				con.warn('hyper ok', caap.hyper);
+				con.log(1, 'Multiple accounts configured, so enabling hyper visor functions!', caap.hyper);
 			}
 			
             if (caap.domain.which === 0) {

--- a/Chrome/unpacked/js/caap_monster.js
+++ b/Chrome/unpacked/js/caap_monster.js
@@ -542,13 +542,13 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
     caap.monsters = function () {
         try {
-		var whenMonster = config.getItem('WhenMonster', 'Never');
+			var whenMonster = config.getItem('WhenMonster', 'Never');
 
-		if (whenMonster === 'Never' || whenMonster == 'Review Only') {
-                caap.setDivContent('monster_mess', whenMonster == 'Never' ? 'Monster off' : 'No current review');
-                return false;
-            }
-			
+			if (whenMonster === 'Never' || whenMonster == 'Review Only') {
+				caap.setDivContent('monster_mess', whenMonster == 'Never' ? 'Monster off' : 'No current review');
+				return false;
+			}
+				
 			monster.select(false);
 			
             ///////////////// Reivew/Siege all monsters/raids \\\\\\\\\\\\\\\\\\\\\\
@@ -1848,11 +1848,16 @@ id = $u.setContent(id, $u.setContent($j("#app_body #chat_log button[onclick*='aj
 						tempDiv = $j("#app_body div[style*='button_cost_stamina_']");
 						if (tempDiv.length) {
 							cM.siegeLevel = tempDiv.attr('style').match(/button_cost_stamina_(\d+)/)[1];
-							siegeLimit = !cM.conditions ? false : cM.conditions.match(':!s') ? 0 : monster.parseCondition("s", cM.conditions);
+							//siegeLimit = !cM.conditions ? false : cM.conditions.match(':!s') ? 0 : monster.parseCondition("s", cM.conditions);
+
+							siegeLimit = !cM.conditions ? false : cM.conditions.match(':!s:') ? 0
+								: !cM.conditions.match(':fs:') ? monster.parseCondition("s", cM.conditions)
+								: caap.stats.stamina.max == caap.stats.stamina.num ? 50 : 1;
 							siegeLimit = siegeLimit !== false ? siegeLimit : config.getItem('siegeUpTo','Never') === 'Never' ? 0 : config.getItem('siegeUpTo','Never');
 							
-							cM.doSiege = cM.siegeLevel <= siegeLimit && cM.phase > 1 && caap.hasImage('siege_btn.gif') && cM.damage > 0;
-							con.log(2, "Page Review " + (cM.doSiege ? 'DO siege ' : "DON'T siege ") + cM.name, cM.siegeLevel, siegeLimit, cM.phase, config.getItem('siegeUpTo','None'));
+							cM.doSiege = cM.siegeLevel <= siegeLimit && caap.hasImage('siege_btn.gif') && cM.damage > 0 
+								&& (cM.phase > 1 || (cM.conditions && cM.conditions.match('fs')));
+							con.log(2, "Page Review " + (cM.doSiege ? 'DO siege ' : "DON'T siege ") + cM.name, cM.siegeLevel, siegeLimit, cM.phase, config.getItem('siegeUpTo','None'), cM.conditions.match(':fs:'), cM.conditions.match(':!s:'));
 							
 						} else {
 							cM.doSiege = false;

--- a/Chrome/unpacked/js/caap_start.js
+++ b/Chrome/unpacked/js/caap_start.js
@@ -55,7 +55,7 @@ caap_timeout,retryDelay,devVersion,caapVersion */
 			return;
 		}
 
-		if (caap.domain.which >= 0 && caap.domain.which < 2) {
+		if ([0, 1].indexOf(caap.domain.which) >= 0) {
 			FBID = $u.setContent(caap.fbEnv.id, 0).parseInt();
 			aName = $j('#pageNav .headerTinymanName').text();
 		} else if (caap.domain.which == 2 && caap.hasImage('tab_stats_on.gif') && $j("#app_body a[href*='keep.php?user=']")) {
@@ -106,7 +106,8 @@ caap_timeout,retryDelay,devVersion,caapVersion */
                                     window.caap = null;
                                     window.con = null;
                                     window.conquest = null;
-									if (window.location.href.indexOf('web3.castleagegame.com/castle_ws') >= 0) {
+									if (window.location.href.indexOf('web3.castleagegame.com/castle_ws') >= 0 
+										|| window.location.href.indexOf('apps.facebook.com/castle_age') >= 0) {
 										window.location.href = 'https://web3.castleagegame.com/castle_ws/keep.php';
 									} else {
 										$u.reload();

--- a/Chrome/unpacked/js/feed.js
+++ b/Chrome/unpacked/js/feed.js
@@ -690,7 +690,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					}
 					if (monsterName.toLowerCase().hasIndexOf(filterList[i].match(new RegExp("^[^:]+")).toString().trim())) {
 						monsterConditions = filterList[i].replace(new RegExp("^[^:]+"), '').toString().trim();
-						return monsterConditions.length ? monsterConditions : '';
+						return monsterConditions.length ? ':' +  monsterConditions + ':' : '';
 					}
 				}
 				return false;
@@ -735,7 +735,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 				feed.scanRecord = {};
                 if (tR) {
 					monsterInfo = monster.getInfo(tR);
-					result = caap.navigate2('@MonsterGeneral,ajax:' + tR.link + (monsterInfo.alpha ? ',clickimg:battle_enter_battle.gif,expansion_monster_class_choose,clickjq:#choose_class_screen .banner_warlock input[src*="nm_class_select.gif"]' : ',clickimg:button_nm_p_power_attack.gif'));
+					result = caap.navigate2('@MonsterGeneral,ajax:' + tR.link + (monsterInfo.alpha ? ',clickimg:battle_enter_battle.gif,expansion_monster_class_choose,clickjq:#choose_class_screen .banner_warlock input[src*="nm_class_select.gif"]' : ',clickimg:button_nm_p_attack.gif'));
 					if (result === 'fail') {
 						return caap.navigate2('player_monster_list');
 					}

--- a/Chrome/unpacked/js/functions.js
+++ b/Chrome/unpacked/js/functions.js
@@ -139,8 +139,8 @@ function caap_clickRelogin() {
 	
 	var logonArray = hyper.getItem('logons', false),
 		logonObj = {},
-		testObj = {'player_email' : 'fakeEmail@mailinator.com',
-			'password' : 'not_a_real_account'};
+		testObj = [{'player_email' : 'fakeEmail@mailinator.com',
+			'password' : 'not_a_real_account'}];
 
 	if ($u.isArray(logonArray)) {
 		if (logonArray.length > 0) {

--- a/Chrome/unpacked/js/general.js
+++ b/Chrome/unpacked/js/general.js
@@ -190,10 +190,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 timeStrings = '',
                 now = new Date();
             // Priority generals, such as Guild Battle class generals, outrank timed generals.
-            if (!caap.stats.priorityGeneral || caap.stats.priorityGeneral == 'false' || caap.stats.priorityGeneral == false) {
-                con.log(2,'Priority gen reset to "Use Current"');
-		caap.stats.priorityGeneral = 'Use Current';
-            }
             if (caap.stats.priorityGeneral != 'Use Current') {
                 timeStrings = now.toLocaleTimeString().replace(/:\d+ /,' ') + '@' + caap.stats.priorityGeneral;
                 timedLoadoutsList.unshift(timeStrings);
@@ -369,11 +365,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					uGR = general.getRecord(usedGen);
 					['energy', 'stamina', 'health'].forEach(function(stat) {
 						if (general.isLoadout(usedGen)) {
-							caap.stats[stat].min = Math.min(caap.stats[stat].min, uGR[stat]);
+							caap.stats[stat].min = Math.min(caap.stats[stat].min, $u.setContent(uGR[stat], 0));
 						} else if (defaultLoadout == 'Use Current') {
-							caap.stats[stat].min = Math.min(caap.stats[stat].min, uGR[stat]);
+							caap.stats[stat].min = Math.min(caap.stats[stat].min, $u.setContent(uGR[stat], 0));
 						} else {
-							caap.stats[stat].min = Math.min(caap.stats[stat].min, uGR[stat] + general.getRecord(defaultLoadout)[stat]);
+							caap.stats[stat].min = Math.min(caap.stats[stat].min, $u.setContent(uGR[stat] + general.getRecord(defaultLoadout)[stat], 0));
 						}
 						//con.log(2, 'Min loadout/general en/sta adjustment calc', uGR, caap.stats[stat].min, caap.stats[stat]);
 					});
@@ -528,6 +524,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     caap.updateDashboard(true);
                     general.UpdateDropDowns();
                 }
+				
+				// Add code to check for a general level up pop-up here?
 
                 con.log(5, "loadoutslist done", general.records);
                 return true;
@@ -974,7 +972,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             }
 
             con.log(2, 'Changing from ' + currentGeneral + ' to ' + targetGeneral);
-            if (caap.navigateTo('mercenary,generals', 'tab_generals_on.gif')) {
+            if (caap.navigateTo('generals')) {
                 return true;
             }
 

--- a/Chrome/unpacked/js/guild_battle.js
+++ b/Chrome/unpacked/js/guild_battle.js
@@ -1204,7 +1204,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				caap.stats.priorityGeneral = config.getItem('10v10 ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('10v10 ClassGeneral','Use Current');
 			}
 			if (caap.stats.priorityGeneral == 'Use Current' && gRecord.state == 'PreBattle') {
-				caap.stats.priorityGeneral = ((config.getItem('GB ClassGeneral','Use Current') == 'Use Current') ? 'Use Current' : config.getItem('GB ClassGeneral','Use Current'));
+				caap.stats.priorityGeneral = config.getItem('GB ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('GB ClassGeneral','Use Current');
 			}
 			if (caap.stats.priorityGeneral != 'Use Current') {
 				con.log(2,gf.abbrev + ' PREBATTLE general',caap.stats.priorityGeneral);

--- a/Chrome/unpacked/js/monster.js
+++ b/Chrome/unpacked/js/monster.js
@@ -2574,7 +2574,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
                         }
 
                         //Monster is a match so we set the conditions
-                        monsterObj.conditions = monsterConditions;
+                        monsterObj.conditions = ':' + monsterConditions + ':';
                         monsterObj.select = true;
                         monster.setItem(monsterObj, 'monster');
                         // If it's complete or collect rewards, no need to process further


### PR DESCRIPTION
-Fix battle invade/duel - the page layout changed a while back apparently, and as a result, Battle invade or duel only read the first target
-Reduce battle invade/duel refresh frequency - with the default set up, battle would mash the refresh on the battle page up to 20 times in 45 seconds when looking for new targets, despite new targets only appearing once a minute. We want to avoid this kind of load on the CA servers. I reduced to two refreshes per minute.
-Fix for FB not loading due to hyper function not defined
-Fix for hyper default local storage entry not having outside parentheses
-Fix for NaN setting sometimes for max stamina or energy
