### PR TITLE
Monster stamina tracking

### DIFF
--- a/Chrome/unpacked/js/battle.js
+++ b/Chrome/unpacked/js/battle.js
@@ -1085,7 +1085,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     }
                 }
 				
-				con.log(2, 'Battle target stats:', tempRecord.data.nameStr, tempRecord.data.levelNum, tempRecord.data.rankStr, tempRecord.data.rankNum, tempRecord.data.armyNum);
+				con.log(3, 'Battle target stats:', tempRecord.data.nameStr, tempRecord.data.levelNum, tempRecord.data.rankStr, tempRecord.data.rankNum, tempRecord.data.armyNum);
 
                 if (battle.hashCheck(tempRecord.data)) {
                     inputDiv = null;
@@ -1111,7 +1111,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 }
 
                 if (tempRecord.data.levelNum - caap.stats.level > maxLevel) {
-                    con.log(2, "Exceeds relative maxLevel", {
+                    con.log(3, "Exceeds relative maxLevel", {
                         'level': tempRecord.data.levelNum,
                         'levelDif': tempRecord.data.levelNum - caap.stats.level,
                         'maxLevel': maxLevel
@@ -1126,7 +1126,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 }
 
                 if (caap.stats.level - tempRecord.data.levelNum > minLevel) {
-                    con.log(2, "Exceeds relative minLevel", {
+                    con.log(3, "Exceeds relative minLevel", {
                         'level': tempRecord.data.levelNum,
                         'levelDif': caap.stats.level - tempRecord.data.levelNum,
                         'minLevel': minLevel
@@ -1142,7 +1142,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
                 if (config.getItem("BattleType", 'Invade') === "War" && battle.battles.Freshmeat.warLevel) {
                     if (caap.stats.rank.war && (caap.stats.rank.war - tempRecord.data.warRankNum > minRank)) {
-                        con.log(2, "Greater than war minRank", {
+                        con.log(3, "Greater than war minRank", {
                             'rankDif': caap.stats.rank.war - tempRecord.data.warRankNum,
                             'minRank': minRank
                         });
@@ -1156,7 +1156,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     }
                 } else {
                     if (caap.stats.rank.battle && (caap.stats.rank.battle - tempRecord.data.rankNum > minRank)) {
-                        con.log(2, "Greater than battle minRank", {
+                        con.log(3, "Greater than battle minRank", {
                             'rankDif': caap.stats.rank.battle - tempRecord.data.rankNum,
                             'minRank': minRank
                         });
@@ -1172,7 +1172,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
                 // if we know our army size, and this one is larger than armyRatio, don't battle
                 if (config.getItem('BattleType', 'Invade') == 'Invade' && caap.stats.army.capped && (tempRecord.data.armyNum > (caap.stats.army.capped * armyRatio))) {
-                    con.log(2, "Greater than armyRatio", {
+                    con.log(3, "Greater than armyRatio", {
                         'armyRatio': armyRatio.dp(2),
                         'armyNum': tempRecord.data.armyNum,
                         'armyMax': (caap.stats.army.capped * armyRatio).dp()

--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -2302,7 +2302,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			});
 			result = Math[minMax].apply(null, array);
 
-            return result == Number.POSITIVE_INFINITY ? undefined : result;
+            return result == Number.POSITIVE_INFINITY || result == Number.NEGATIVE_INFINITY ? undefined : result;
         } catch (err) {
             con.error("ERROR in minMaxArray: " + err + ' ' + err.stack);
             return undefined;
@@ -3849,7 +3849,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
                     break;
                 case "festivalTower":
-                    monster.fullReview();
+                    monster.select(true);
 
                     break;
                 default:
@@ -4088,7 +4088,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             if (/AttrValue+/.test(idName)) {
                 state.setItem("statsMatch", true);
             } else if (/MaxToFortify/.test(idName)) {
-                monster.fullReview();
+                monster.select(true);
             } else if (/Chain/.test(idName)) {
                 state.getItem('BattleChainId', 0);
             } else if (idName === 'DebugLevel') {
@@ -4291,7 +4291,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     break;
                 case "orderbattle_monster":
                 case "orderraid":
-                    monster.fullReview();
+                    monster.select(true);
                     break;
                 case "BattleTargets":
                     state.setItem('BattleChainId', 0);
@@ -5185,7 +5185,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             //- reverting back to previous d27 behaviour -- magowiz
 
             if ((monster.records.length === 0) && ((AFrecentAction === true))) {
-                monster.fullReview();
+                monster.select(true);
             }
 
             if (general.quickSwitch) {

--- a/Chrome/unpacked/js/caap_battle.js
+++ b/Chrome/unpacked/js/caap_battle.js
@@ -241,7 +241,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 state.setItem("notSafeCount", 0);
             }
 
-            con.log(2, 'Battle Target', target);
+            //con.log(2, 'Battle Target', target);
             targetType = config.getItem('TargetType', 'Invade');
             switch (target) {
             case 'raid':

--- a/Chrome/unpacked/js/general.js
+++ b/Chrome/unpacked/js/general.js
@@ -983,7 +983,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					}
 					con.log(2,'Loading ' +targetLoadout + ' value ' + lRecord.value, lRecord);
 
-					general.clickedLoadout = lRecord.value-1;
+					general.clickedLoadout = lRecord.value - 1;
 					caap.click($j('div[id*="hot_swap_loadouts_content_div"] > div:nth-child(' + lRecord.value + ') > div:first'));
 					return true;
 				}


### PR DESCRIPTION
Monster
Implement stamina/energy use tracking per monster. This can be seen on
the title for damage on the dashboard
Also enabled new monster target string modifier :sta, which can be used
to set a limit on how much stamina will be used on a monster, such as
:sta1k to limit stamina use to 1000 stamina
Change config changes for the monster target setting to reselect target,
instead of deleting all monster data to rescan, which would delete
stamina/energy history
Fix for double 's after player name in Festival monsters
Fix monster stamina/energy targeting to address case when no levels
available

Guild Battle
Fix festival battles getting missed because timer reset just before
battle
Fix some errors in GB automatic starting by time -- not sure this works
again yet
Add a priority to GB tower review, so it is not continually interrupted
by Festival or 10v10
Reduce unnecessary GB idle general changes, such as when collecting

Other
Reduce Battle log messages at error level 2
