### PR TITLE
Auto-join and Heal my damage

### DIFF
--- a/Chrome/unpacked/js/caap_festival.js
+++ b/Chrome/unpacked/js/caap_festival.js
@@ -15,8 +15,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
     caap.checkResults_festival_battle_home = function () {
         try {
+			var fR = guild_battle.getItem(guild_battle.gf.festival);
 			//caap.globalContainer.find("input[src*='battle_enter_battle']").on('click', festival.engageListener);
-			return true;
+			fR.state = !caap.hasImage('festival_arena_enter.jpg') ? 'No battle' : fR.state;
+			guild_battle.setrPage(fR, 'index', 'review', 0);
+			
         } catch (err) {
             con.error("ERROR in checkResults_festival_battle_home: " + err);
             return false;

--- a/Chrome/unpacked/js/caap_guildbattle.js
+++ b/Chrome/unpacked/js/caap_guildbattle.js
@@ -54,8 +54,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         try {
 			var fR = guild_battle.getItem(guild_battle.gf.tenVten);
 			//con.log(1,'tenv10', !caap.hasImage('fb_guild_btn_joinbattle_small.gif'), fR.state == 'Active', fR);
-            if (!caap.hasImage('fb_guild_btn_joinbattle_small.gif') && fR.state == 'Active') {
-				fR.state = 'Collect';
+            if (!caap.hasImage('fb_guild_btn_joinbattle_small.gif') && (fR.state == 'Active' || fR.state == 'Collect')) {
+				fR.state = 'No battle';
 			}
         } catch (err) {
             con.error("ERROR in caap.checkResults_tenxten_gb_formation: " + err.stack);

--- a/Chrome/unpacked/js/caap_monsterdash.js
+++ b/Chrome/unpacked/js/caap_monsterdash.js
@@ -93,7 +93,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 throw "We are missing the Dashboard div!";
             }
 
-            if (!caap.oneMinuteUpdate('dashboard', force) && $j('#caap_infoMonster').html()) {
+            if (!caap.oneMinuteUpdate('dashboard', force)) {
                 if (caap.updateDashboardWaitLog) {
                     con.log(4, "Dashboard update is waiting on oneMinuteUpdate");
                     caap.updateDashboardWaitLog = false;
@@ -1107,10 +1107,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 //        caap.updateDashboard(true);
     };
 
-    caap.refreshMonstersListener = function () {
-        monster.fullReview('Monster');
-    };
-
+	// Pass through function used to pass arguments that might not be referred from a different context
     caap.refreshFeedListener = function () {
         monster.fullReview('Feed');
     };
@@ -1230,7 +1227,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
             $j('#caap_DBDisplay', caap.caapTopObject).on('change', caap.dbDisplayListener);
             $j('#caap_GFDisplay', caap.caapTopObject).on('change', caap.gfDisplayListener);
-            $j('#caap_refreshMonsters', caap.caapTopObject).on('click', caap.refreshMonstersListener);
+            $j('#caap_refreshMonsters', caap.caapTopObject).on('click', monster.fullReview);
             $j('#caap_refreshFeeds', caap.caapTopObject).on('click', caap.refreshFeedListener);
             $j('#caap_refreshGenerals', caap.caapTopObject).on('click', caap.refreshGeneralsListener);
             $j('#caap_refreshGuildMonsters', caap.caapTopObject).on('click', caap.refreshGuildMonstersListener);


### PR DESCRIPTION
Monster
Monsters can now be auto-joined. Details on the info link next to the
Monster Finder.
Added a new option for fortifying that will only heal the damage you
cause. A maximum percentage amount of the stamina spent is set and after
attacking, CAAP will heal until the Fortification percent is greater
than when you started or until the percentage of stamina is reached. For
example, if set to the default of 20%, and CAAP started hitting when the
monster was at 95% health and used 200 stamina, CAAP would heal until
the health was back above 95% or until it had used 200 \* 20% = 40
energy, whichever came first. This healing will ignore other energy
usage limitations. Set to 0% to disable. If not disabled, then stamina
that can be spent attacking monsters will be limited by the amount of
energy you have available to heal.
Quests now has a new choice for when to quest, called when "Not Covering
My Damage." This will hold in reserve the amount of energy you need to
cover your current stamina, and heal the rest. For example, if you have
300 stamina and set reserves to 20%, it would save 60 energy, and spent
any energy over that on quests.
Fix several issues with attacking and fortifying monsters
Remove the delete all monster records CAAP did every time you levelled
up
Remove Power Fortify Max option. CAAP will fortify for the most possible
when levelling up. Otherwise, it will use the smallest fortify.
Correct siege phase for old style LoM monsters
Tweak for Dashboard refresh. Hopefully the dashboard will refresh faster
for monsters
Improve general detection for monsters to decide if using a multiplier
general like Maalvus

GB
Improve collecting and entering battles
Reduce guild battle checking when using tokens "over" or stunned. CAAP
will burn at least two tokens after it does a tower review.
Fix for starting classic guild battles
Fix data structure for GB, so the records are not nestled one layer down
below a "data" object
Reduce limitations of what can be done when CAAP is pausing for a class
or timed loadout

Other
Added a new function to clean records, such as monster.records or
general.records, which will add any blank fields from the template and
notice any fields which are not in the template, and inform in the logs.
This reduces the need for deleting records to fill in missing fields or
add lots of error checking into the code because it's not sure if a
field will be present or not.
Improve code speed for building general lists
