### PR TITLE
LoM fixes

### DIFF
--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -8229,7 +8229,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			}
 
             if (['Energy Available', 'Not Fortifying', 'Not Covering My Damage'].indexOf(condition) >=0) {
-				energyMin = Math.max(0, caap.stats.energy.num - (condition == 'Not Covering My Damage' ? caap.stats.stamina.num * config.getItem('HealPercStam', 20) / 100 : 0));
+				energyMin = Math.max(0, caap.stats.energy.num - (condition == 'Not Covering My Damage' ? Math.max( 20, caap.stats.stamina.num * config.getItem('HealPercStam', 20) / 100) : 0));
                 if (energyMin >= energyRequired) {
                     return energyMin;
                 }
@@ -8261,7 +8261,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				caap.setDivContent(msgdiv, which + 'Waiting for X energy: ' + caap.stats.energy.num + "/" + whichEnergy);
             } else if (condition === 'At Max Energy') {
                 if (caap.stats.energy.num >= maxIdleEnergy) {
-                    return caap.stats.energy.num - maxIdleEnergy;
+                    return caap.stats.energy.num;
                 }
 				if (msgdiv === "quest_mess") {
 					window.clearTimeout(caap.qtom);
@@ -9532,11 +9532,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				myLand = conquestLands.records[myIndex];
 				// If I can move, and there is an enter-able land with enough time for me to join it and get back to my land, then join.
 				if (myLand.status == 'enter' && nextLand.index !== myIndex && myLand.phaseLeft > Math.min(nextLand.phaseLeft + 24, nextLand.timeLeft) + 3) {
-					result = caap.navigate2('guildv2_conquest_command,click:_smallX.jpg');
+					result = caap.navigate2('ajax:guildv2_conquest_command.php?tier=3,clickimg:_smallX.jpg');
 					caap.stats.LoMland = result == 'done' ? -1 : caap.stats.LoMland;
 				}
 			}
-			if (result == 'fail' || result == 'done') {
+			if (result == 'fail') {
 				schedule.setItem('LoMmoveWait', 5 * 60);
 			}
             return result == 'done' || result === true;

--- a/Chrome/unpacked/js/caap_monster.js
+++ b/Chrome/unpacked/js/caap_monster.js
@@ -1436,10 +1436,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 							});
 						}
 					} else {
-						cM.staminaList = monster.getInfo(cM, 'staminaList');
 						if (!cM.staminaList.length) {
-							con.warn('Unable to find stamina/energy attack buttons');
+							con.log(2, 'Unable to find stamina/energy attack buttons, so using default configuration');
 						}
+						cM.staminaList = monster.getInfo(cM, 'staminaList');
+						cM.energyList = cM.fortify >= 0 ? monster.getInfo(cM, 'energyList') : [];
 					}
 						
 				// It's alive and I haven't hit it

--- a/Chrome/unpacked/js/feed.js
+++ b/Chrome/unpacked/js/feed.js
@@ -690,7 +690,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					if (monsterName.toLowerCase().hasIndexOf(filterList[i].match(/^[^:]+/i).toString().trim())) {
 						monsterConditions = filterList[i].replace(/^[^:]+/i, '').toString().trim();
 						if ($u.isObject(cM)) {
-							cM.conditions = monsterConditions;
+							cM.conditions = monsterConditions + ':';
 							feed.scoring(cM);
 						}
 						return monsterConditions.length ? monsterConditions + ':' : '';
@@ -819,17 +819,18 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					staminamax = caap.maxStatCheck('stamina'),
 					stamina = caap.stats.stamina.num,
 					exp = caap.stats.exp.dif,
-					ach = caap.stats.achievements.monster;
+					ach = caap.stats.achievements.monster,
+					conq = cM.lpage == "ajax:player_monster_list.php?monster_filter=2";
 					
-					if (cM.conditions.regex(/:j\[(.*)\][:\s,]/)) {
-						cM.score = eval($u.setContent(cM.conditions.regex(/:s\[(.*)\][:\s,]/), 0)).dp(2);
-						cM.join = eval(cM.conditions.regex(/:j\[(.*)\][:\s,]/));
-						con.log(1, (cM.join ? 'Join candidate' : 'Do not join') + '. Score: ' + cM.score, cM.conditions, cM.conditions.regex(/:s\[(.*)\][:\s,]/), cM.conditions.regex(/:j\[(.*)\][:\s,]/));
+					if (cM.conditions.regex(/:j\[(.*?)\]:/)) {
+						cM.score = eval($u.setContent(cM.conditions.regex(/:s\[(.*?)\]:/), 0)).dp(2);
+						cM.join = eval(cM.conditions.regex(/:j\[(.*?)\]:/));
+						con.log(1, (cM.join ? 'Join candidate' : 'Do not join') + '. Score: ' + cM.score, cM.conditions, cM.conditions.regex(/:s\[(.*?)\]:/), cM.conditions.regex(/:j\[(.*?)\]:/));
 						cM.color = cM.join ? 'green' : $u.bestTextColor(state.getItem("StyleBackgroundLight", "#E0C961"));
 					}
-					if (cM.conditions.regex(/:c\[(.*)\][:\s,]/)) {
-						cM.charClass = eval($u.setContent(cM.conditions.regex(/:c\[(.*)\][:\s,]/), 'Warlock'));
-						con.log(1, 'Class to be set: ' + cM.charClass, cM.conditions.regex(/:c\[(.*)\][:\s,]/));
+					if (cM.conditions.regex(/:c\[(.*?)\]:/)) {
+						cM.charClass = eval($u.setContent(cM.conditions.regex(/:c\[(.*?)\]:/), 'Warlock'));
+						con.log(1, 'Class to be set: ' + cM.charClass, cM.conditions.regex(/:c\[(.*?)\]:/));
 					}
 					
             } catch (err) {

--- a/Chrome/unpacked/js/monster.js
+++ b/Chrome/unpacked/js/monster.js
@@ -582,7 +582,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 				return false;
             }
 
-            var str = conditions.match(new RegExp(':' + type + '([\\d\\.]*)(\\w?)'));
+            var str = conditions.regex(new RegExp(':' + type + '([\\d\\.]*)(\\w?)'));
 			
 			if (!str) {
 				return false;
@@ -963,6 +963,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
                 s = 0,
 				cM = {},
 				whichList = 'any',
+				conditions = '',
                 selectTypes = [],
 				maxToFortify = 0,
                 nodeNum = 0,
@@ -1018,6 +1019,10 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					}
                 } else {
 					cM.conditions = feed.addConditions(cM) || cM.conditions;
+				}
+				if (cM.status !== 'Attack'){
+					cM.debt.start = -1;
+					cM.debt.stamina = 0;
 				}
             }
 
@@ -1075,13 +1080,15 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
                         if (cM.conditions !== 'none') {
                             return;
                         }
+						conditions = aoItem.replace(new RegExp("^[^:]+"), '').toString().trim();
                         // If this monster does not match, skip to next one
-                        if (!monster.getItem(thisMon).name.toLowerCase().hasIndexOf(aoItem.match(new RegExp("^[^:]+")).toString().trim().toLowerCase())) {
+                        if (!monster.getItem(thisMon).name.toLowerCase().hasIndexOf(aoItem.match(new RegExp("^[^:]+")).toString().trim().toLowerCase()) && (conditions.regex(/(:conq)\b/) != (cM.lpage == "ajax:player_monster_list.php?monster_filter=2"))) {
                             return;
                         }
 
                         //Monster is a match so we set the conditions
-                        cM.conditions = aoItem.replace(new RegExp("^[^:]+"), '').toString().trim();
+                        cM.conditions = conditions;
+						cM.fullC = aoItem;
 
 						cM.select = true;
 
@@ -1094,13 +1101,12 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 						monster.parsing(cM);
 						
 						if (cM.siegeLevel > 0) {
-							siegeLimit = !cM.conditions ? false : cM.conditions.match(':!s:') ? 0
-								: !cM.conditions.match(/:fs\b/) ? monster.parseCondition("s", cM.conditions)
+							siegeLimit = conditions.regex(/:!s\b/) ? 0 : !conditions.regex(/:fs\b/) ? monster.parseCondition("s", cM.conditions) 
 								: (caap.stats.stamina.num >= caap.maxStatCheck('stamina') && cM.phase > 2) ? 50 : 1;
 							siegeLimit = siegeLimit !== false ? siegeLimit : config.getItem('siegeUpTo','Never') === 'Never' ? 0 : config.getItem('siegeUpTo','Never');
 							
 							cM.doSiege = cM.siegeLevel <= siegeLimit && cM.damage > 0 
-								&& (cM.phase > 1 || (cM.conditions && cM.conditions.match('fs')));
+								&& (cM.phase > 1 || (conditions && conditions.regex(/:fs\b/)));
 							//con.log(2, "Page Review " + (cM.doSiege ? 'DO siege ' : "DON'T siege ") + cM.name, cM.siegeLevel, siegeLimit, cM.phase, config.getItem('siegeUpTo','None'), cM.conditions.match(':fs:'), cM.conditions.match(':!s:'));
 						} else {
 							cM.doSiege = false;
@@ -1584,7 +1590,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 
                     if (monsterConditions && monsterConditions !== 'none') {
                         data = {
-                            text: '<span title="User Set Conditions: ' + monsterConditions + '" class="ui-icon ui-icon-info">i</span>',
+                            text: '<span title="User Set Condition string: ' + cM.fullC + '" class="ui-icon ui-icon-info">i</span>',
                             color: 'blue',
                             id: '',
                             title: ''


### PR DESCRIPTION
Finder
Fix for Finder not joining monsters
Allow Finder conditions to contain brackets like "+ ach['Kiera']"
Add conq variable to be used in Finder strings. It's true for conquest
lands

Monster
Fix Not Covering my Damage to keep 20 energy
Add full monster order string match into dashboard title to help
troubleshooting
Fix for caap stopping monster due to trying to cover damage on dead
monsters
Add ":conq" condition to match only conquest monsters for min/max
damages

Other
Fix for At Max Energy settings not working
Fix for LoM not leaving a land to join a new one
