### PR TITLE
Battle record standardisation

### DIFF
--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -5279,7 +5279,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         session.setItem("UserDashUpdate", true);
     };
 
-
     caap.saveStats = function (src) {
         if (caap.domain.which === 3) {
            caap.messaging.setItem('caap.stats', caap.stats);

--- a/Chrome/unpacked/js/caap_dashboard.js
+++ b/Chrome/unpacked/js/caap_dashboard.js
@@ -113,7 +113,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             guild_monster.dashboard();
             arena.dashboard();
             feed.dashboard();
-            conquest.dashboard();
             guilds.dashboard();
             gifting.queue.dashboard();
             gifting.history.dashboard();

--- a/Chrome/unpacked/js/head.js
+++ b/Chrome/unpacked/js/head.js
@@ -69,6 +69,10 @@ Number.prototype.numberOnly = function() {
     return this.valueOf();
 };
 
+Number.prototype.r1000 = function() {
+    return (this / 1000).dp(0);
+};
+
 Array.prototype.flatten = function(f, lc) {
 	 return this.map( function(o) {
 		return lc ? o[f].toLowerCase() : o[f];
@@ -118,6 +122,12 @@ Array.prototype.deleteObjs = function(f, v) {
 	return this.filter( function(e) {
 		return e[f] !== v;
 	});
+};
+
+Array.prototype.listMatch = function(r) {
+	return this.reduce( function(p, c) {
+		return $u.setContent(p, c.regex(r));
+	}, null);
 };
 
 String.prototype.parseTimer = function() {

--- a/Chrome/unpacked/js/worker_arena.js
+++ b/Chrome/unpacked/js/worker_arena.js
@@ -210,7 +210,7 @@
 				}
 
 				if ($u.hasContent(result.battleType)) {
-					result.points = caap.regexDiv(resultsDiv, /You have .* \+?(\d+) Arena Points/);
+					result.points = caap.bulkRegex(resultsDiv, /You have .* \+?(\d+) Arena Points/);
 					if (!$u.hasContent(result.points)) {
 						con.warn("Unable to match arena points", tempText);
 					}
@@ -258,9 +258,9 @@
 				var thisDiv    = $j(this),
 					fR = {}; // feed record
 				
-				// regexDiv broken into two parts because double-byte char names can cause regex match to fail
-				caap.regexDiv(thisDiv, /(.*) level: \d+ .+ \(Rank \d\) \d+/, fR, 'nameStr');
-				caap.regexDiv(thisDiv, /level: (\d+) (.+) \(Rank (\d)\) (\d+)/, fR,
+				// bulkRegex broken into two parts because double-byte char names can cause regex match to fail
+				caap.bulkRegex(thisDiv, /(.*) level: \d+ .+ \(Rank \d\) \d+/, fR, 'nameStr');
+				caap.bulkRegex(thisDiv, /level: (\d+) (.+) \(Rank (\d)\) (\d+)/, fR,
 					['levelNum', 'rankStr', 'arenaRankNum', 'armyNum']);
 
 				fR.userId = $j("input[name*='target_id']", inputDiv[index].children[4].children[0].children[0])[0].value;
@@ -372,7 +372,7 @@
 				arenaPageTf = session.getItem('page', '') == 'arena',
 				arenaTokens = arenaPageTf ? $j("span[id*='guild_token_current_value']")[0].innerHTML : state.getItem("arenaTokens", 10),
 				inputDiv = arenaPageTf ? $j("div[style*='arena_infobar']") : $j(),
-				timer = arenaPageTf ? caap.regexDiv($j("#arena_health_bar_hover"), /(\d+)m until recharge/) : 0,
+				timer = arenaPageTf ? caap.bulkRegex($j("#arena_health_bar_hover"), /(\d+)m until recharge/) : 0,
 				pastWins = true,
 				recon = config.getItem('arenaRecon', false) ? 1 * 60 : 24 * 3600,
 				randomNum = Math.random() * 100,
@@ -584,9 +584,9 @@
 					return;
 				}
 				tempDiv = $j("#app_body #newsFeedSection div[id^='battle_messages_" + tR.userId + "']:contains('Arena Battle Points')");
-				tR.arenaPoints = tR.arenaPoints ? tR.arenaPoints : caap.regexDiv(tempDiv, /You have won (\d+) Arena Battle Points!/);
+				tR.arenaPoints = tR.arenaPoints ? tR.arenaPoints : caap.bulkRegex(tempDiv, /You have won (\d+) Arena Battle Points!/);
 				tR.arenaRevenge = true;
-				tR.duelwinsNum = tR.duelwinsNum ? tR.duelwinsNum : caap.regexDiv($j(infoDiv[index]).next(), /You won (\d+) times/) || 1;
+				tR.duelwinsNum = tR.duelwinsNum ? tR.duelwinsNum : caap.bulkRegex($j(infoDiv[index]).next(), /You won (\d+) times/) || 1;
 				battle.setItem(tR);
 				con.log(2, 'Arena victory in feed against ' + tR.nameStr + '. Last points: ' + tR.arenaPoints, tR);
 			});

--- a/Chrome/unpacked/js/worker_caap.js
+++ b/Chrome/unpacked/js/worker_caap.js
@@ -57,7 +57,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			}
 //			con.log(2,"Idle Check equipped", timedLoadoutCheck, caap.stats.battleIdle);
 			if (caap.stats.battleIdle != 'Use Current' ? general.Select(caap.stats.battleIdle) 
-				: (config.getItem('IdleGeneral', 'Use Current') != 'Use Current') 
+				: (config.getItem('IdleGeneral', 'Use Current') == 'Use Current') 
 				? general.Select(state.getItem('lastLoadout', 'Use Current')) || general.Select(state.getItem('lastGeneral', 'Use Current'))
 				: general.Select('IdleGeneral')) {
 				return true;

--- a/Chrome/unpacked/js/worker_conquest.js
+++ b/Chrome/unpacked/js/worker_conquest.js
@@ -1704,7 +1704,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
-    caap.scoutGuildEssence = function() {
+	worker.addAction({worker : 'guilds', priority : -2600, description : 'Scout Guild Essence'});
+
+    guilds.worker = function() {
         try {
             if (config.getItem('EssenceScanCheck', false)) {
                 var guildId, link;
@@ -1722,7 +1724,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
             return false;
         } catch (err) {
-            con.error("ERROR in caap.schoutGuilEssence: " + err);
+            con.error("ERROR in guilds.worker: " + err);
             return false;
         }
     }

--- a/Chrome/unpacked/js/worker_feed.js
+++ b/Chrome/unpacked/js/worker_feed.js
@@ -60,8 +60,8 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 						}
 						var picDiv = $j('img[src*="' + p + '"]');
 						if (picDiv) {
-							pR.image = picDiv.attr('src').regex(/(\w+\.\w+)$/);
-							pR.name = picDiv.attr('title');
+							pR = town.getRecord(picDiv.attr('src').regex(/(\w+\.\w+)$/));
+							pR.name = picDiv.attr('alt');
 							pR.owned = picDiv.closest('div').next().text().innerTrim().trim().regex(/(\d+)/);
 							town.setRecord(pR);
 						}
@@ -281,6 +281,10 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 				},
 				needname = function(name, want) {
 					return want > nameowned(name);
+				},
+				userdamage = function(userId, damage) {
+					state.setItem('feedUserId', state.getItem('feedUserId', '').split('\n').addToList(name).join('\n'));
+					return $u.setContent(cM.userDamage.regex(new RegExp('\\b' + userId + ':(\\d+)'), 0) >= damage;
 				},
 				keep = worker.pagesList.flatten('page').hasIndexOf('ajax:' + cM.link),
 				achleft = 0,

--- a/Chrome/unpacked/js/worker_general.js
+++ b/Chrome/unpacked/js/worker_general.js
@@ -845,8 +845,11 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 				if (!config.getItem('saveLoadouts', true)) {
 					con.warn('Unable to find ' + targetGeneral + ' record for ' + whichGeneral + '.  Changing setting to "Use Current"');
 					general.Clear(whichGeneral);
-					return returnNametf ? 'Use Current' : false;
+				} else {
+					con.warn('Unable to find ' + targetGeneral + ' record for ' + whichGeneral + '. Loadouts reset, maybe? Ignoring setting.');
 				}
+				return returnNametf ? 'Use Current' : false;
+					
             }
 			
             return general.selectSpecific(targetGeneral, returnNametf);
@@ -1013,14 +1016,16 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
                 timedFreezeInstructions = "If CAAP tries to equip a different general during a timed loadout or Guild Battle, freeze CAAP until time is up.  If not checked, CAAP will continue but without changing the general.",
                 i = 0,
                 coolDown = '',
-                htmlCode = '';
+                htmlCode = '',
+				gen = '';
 
             htmlCode += caap.startToggle('Generals', 'GENERALS');
 			htmlCode += caap.makeCheckTR("Do not clear Loadouts", 'saveLoadouts', true, saveLoadouts);
             htmlCode += caap.makeCheckTR("Filter Generals", 'filterGeneral', true, "Filter General lists for most useable in category.");
             htmlCode += caap.makeDropDownTR("Default Loadout", 'DefaultLoadout', ['Use Current'].concat(general.LoadoutsList), '', '', 'Use Current', false, false, 62);
             general.menuList.forEach( function(g) {
-                htmlCode += caap.makeDropDownTR(g, g.replace(/ /g,'_') + 'General', ['Use Current'].concat(general.lists[g]), '', '', 'Use Current', false, false, 62);
+				gen = g.replace(/ /g,'_') + 'General';
+                htmlCode += caap.makeDropDownTR(g, gen, ['Use Current'].concat(general.lists[g]), '', '', config.getItem(gen, 'Use Current'), false, false, 62);
                 coolDown = general.getCoolDownType(g);
                 htmlCode += coolDown ? caap.makeDropDownTR("Cool", coolDown, general.coolDownList, '', '', '', true, false, 62, '', '_cool_row', general.coolDownList.length > 1 ? "display: block;" : "display: none;") : '';
             });

--- a/Chrome/unpacked/js/worker_loe.js
+++ b/Chrome/unpacked/js/worker_loe.js
@@ -18,19 +18,19 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 	worker.add('loe');
 	
 	gb.loe = {
-		'name' : 'Land of Earth', // Used for user facing text
-		'label' : 'loe', // Used for internal naming
-		'stamina' : 0,
-		'enterButton' : '',
-		'infoDiv' : '',
-		'waitHours' : 24,
-		'collectHours' : 0,
-		'minHealth' : 0, 
+		name: 'Land of Earth', // Used for user facing text
+		label: 'loe', // Used for internal naming
+		stamina: 0,
+		enterButton: '',
+		infoDiv: '',
+		waitHours: 24,
+		collectHours: 0,
+		minHealth: 0, 
 		scoring : 'loeScoring',
-		'basePath' : 'ajax:guildv2_conquest_expansion.php?guild_id='
+		basePath: 'ajax:guildv2_conquest_expansion.php?guild_id='
 	};
 	
-	loe.checkResults = function(page) {
+	loe.checkResults = function(page, resultsText) {
         try {
 			switch (page) {
 			case 'guild_conquest_castle_battlelist' :
@@ -67,7 +67,8 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 					con.warn('Loe guild id is undefined');
 					return;
 				}
-				gb.fightResult(fR);
+				session.setItem('gbWhich', fR.label);
+				battle.readWinLoss(resultsText, gb.testList);
 				
 				$j('#hover_tab_1_1').closest('.tower_tab').find('div[onmouseover*="hover_tab_1_"]').each( function() {
 					var t = $j(this).attr('onmouseover').regex(/hover_tab_1_(\d)/);
@@ -185,6 +186,8 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				gb.setRecord(fR);
 				return caap.navigate2('ajax:guild_conquest_castle_battlelist.php');
 			} else if (result == 'done') {
+				battle.setRecordVal(t.id, 'level', t.level);
+				state.setItem('lastBattleID', t.id);
 				fR.t = false;
 			}
 			gb.setRecord(fR);

--- a/Chrome/unpacked/js/worker_monster.js
+++ b/Chrome/unpacked/js/worker_monster.js
@@ -70,7 +70,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
         };
     };
 
-    monster.checkResults = function (page, ajax, aslice) {
+    monster.checkResults = function (page, resultsText, ajax, aslice) {
         try {
 			var lastClick = $u.setContent(monster.lastClick, session.getItem('clickUrl',''));
 			
@@ -292,7 +292,6 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					if (mR.lpage === lpage && !publicList && mR.status !== 'Join') {
 						if (mR.listReviewed < now) {
 							mR.lMissing += 1;
-							monster.setRecord(mR);
 							con.warn('Did not see monster ' + mR.name + ' on monster list ' + mR.lMissing + ' times.', mR);
 						} else {
 							mR.lMissing = 0;
@@ -713,6 +712,8 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 							con.log(1, 'Joined a feed monster with ' + cM.damage, cM);
 						}
 						cM.status = 'Attack';
+						cM.color = cM.color == 'grey' ? '' : cM.color;
+						
 						// Character type stuff
 						if (cM.charClass) {
 

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -1,0 +1,404 @@
+
+/*jslint white: true, browser: true, devel: true, undef: true,
+nomen: true, bitwise: true, plusplus: true,
+regexp: true, eqeq: true, newcap: true, forin: false */
+/*global window,escape,jQuery,$j,rison,utility,offline,town,gm,
+$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,spreadsheet,ss,
+schedule,gifting,state,army, general,session,monster,guild_monster */
+/*jslint maxlen: 256 */
+
+////////////////////////////////////////////////////////////////////
+//                          Stats OBJECT
+// this is the main object for dealing with stats
+/////////////////////////////////////////////////////////////////////
+
+(function() {
+    "use strict";
+
+	worker.addRecordFunctions({name: 'statsFunc', recordIndex: 'FBID', recordsAreObj: true});
+
+    stats.record = function (FBID) {
+        this.data = {
+			'FBID': FBID,
+			'account': '',
+			'PlayerName': '',
+			'level': 0,
+			'army': {
+				'actual': 0,
+				'capped': 0
+			},
+			'records': {
+				'total': 0,
+				'invade': 0
+			},
+			'attack': 0,
+			'defense': 0,
+			'bonus' : {
+				'attack': 0,
+				'defense': 0,
+				'dpi' : 0,
+				'api' : 0
+			},
+			'points': {
+				'skill': 0,
+				'favor': 0,
+				'guild': 0
+			},
+			'indicators': {
+				'bsi': 0,
+				'lsi': 0,
+				'sppl': 0,
+				'api': 0,
+				'dpi': 0,
+				'mpi': 0,
+				'mhbeq': 0,
+				'htl': 0,
+				'hrtl': 0,
+				'enl': 0,
+				'pvpclass': '',
+				'build': ''
+			},
+			'gold': {
+				'cash': 0,
+				'bank': 0,
+				'total': 0,
+				'income': 0,
+				'upkeep': 0,
+				'flow': 0,
+				'ticker': []
+			},
+			'rank': {
+				'battle': 0,
+				'battlePoints': 0,
+				'war': 0,
+				'warPoints': 0,
+				'conquest': 0,
+				'conquestPoints': 0,
+				'conquestLevel': 0,
+				'conquestLevelPercent': 0
+			},
+			'potions': {
+				'energy': 0,
+				'stamina': 0
+			},
+			'energy': {
+				'norm': 0,
+				'num': 0,
+				'min': 0,
+				'max': 0,
+				'ticker': []
+			},
+			'health': {
+				'norm': 0,
+				'num': 0,
+				'min': 0,
+				'max': 0,
+				'ticker': []
+			},
+			'stamina': {
+				'norm': 0,
+				'num': 0,
+				'min': 0,
+				'max': 0,
+				'ticker': []
+			},
+			'lowpoints' : {
+				'level' : 0,
+				'stamina' : 0,
+				'energy' : 0
+			},
+			'exp': {
+				'num': 0,
+				'max': 0,
+				'dif': 0
+			},
+			'guildTokens': {
+				'num': 0,
+				'max': 0,
+				'dif': 0
+			},
+			'resources': {
+				'lumber': 0,
+				'iron': 0
+			},
+			'conquest': {
+				'Conqueror': 0,
+				'Guardian': 0,
+				'Hunter': 0,
+				'Engineer': 0
+			},
+			'LoMland' : -1,
+			'other': {
+				'qc': 0,
+				'bww': 0,
+				'bwl': 0,
+				'te': 0,
+				'tee': 0,
+				'wlr': 0,
+				'eer': 0,
+				'atlantis': false
+			},
+			'achievements': {
+				'battle': {
+					'invasions': {
+						'won': 0,
+						'lost': 0,
+						'streak': 0,
+						'ratio': 0
+					},
+					'duels': {
+						'won': 0,
+						'lost': 0,
+						'streak': 0,
+						'ratio': 0
+					}
+				},
+				'monster': {},
+				'other': {
+					'alchemy': 0
+				},
+				'feats': {
+					'attack': 0,
+					'defense': 0,
+					'health': 0,
+					'energy': 0,
+					'stamina': 0,
+					'army': 0
+				}
+			},
+			'character': {},
+			'guild': {
+				'name': '',
+				'id': '',
+				'ids' : [], // For your guild mates
+				'level': 0,
+				'levelPercent': 0,
+				'mPoints': 0,
+				'mRank': '',
+				'bPoints': 0,
+				'bRank': '',
+				'members': []
+			},
+			'essence' : {
+				'attack': 0,
+				'defense' : 0,
+				'damage' : 0,
+				'health' : 0
+			},
+			'priorityGeneral' : 'Use Current'
+		};
+    };
+
+	statsFunc.init = function() {
+		try {
+			window.stats = statsFunc.getRecord(FBID);
+       } catch (err) {
+            con.error("ERROR in gb.init: " + err.stack);
+            return false;
+        }
+	};
+	
+	statsFunc.checkResults = function(page) {
+        try {
+			switch (page) {
+			case 'soldiers' :
+			case 'item' :
+			case 'magic' :
+				$j("#app_body form[id*='itemBuy'] select[name='amount']").val("5");
+				schedule.setItem(page, 72 * 3600, 300);
+
+				$j("#app_body div[style*='town_unit_bar.jpg'],div[style*='town_unit_bar_owned.jpg']").each(function() {
+					var row = $j(this),
+						current = new stats.record().data,
+						tempDiv = $j("strong", row).eq(0),
+						tStr = '';
+
+					if ($u.hasContent(tempDiv) && tempDiv.length === 1) {
+						current.name = $u.setContent(tempDiv.text(), '').trim().innerTrim();
+						current.type = page == 'item' ? $u.setContent(spreadsheet.getItem(current.name).type, 'Unknown') : page.ucFirst();
+					} else {
+						con.warn("Unable to get item name in");
+						return;
+					}
+					tempDiv = $j("img", row).eq(0);
+					if ($u.hasContent(tempDiv) && tempDiv.length === 1) {
+						current.image = $u.setContent(tempDiv.attr("src"), '').basename();
+					} else {
+						con.log(3, "No image found for", current.name);
+					}
+
+					tempDiv = $j("span[class='negative']", row);
+					if ($u.hasContent(tempDiv) && tempDiv.length === 1) {
+						current.upkeep = $u.setContent(tempDiv.text(), '0').numberOnly();
+					} else {
+						con.log(4, "No upkeep found for", current.name);
+					}
+
+					tStr = row.children().eq(2).text().trim().innerTrim();
+					if ($u.hasContent(tStr)) {
+						current.atk = $u.setContent(tStr.regex(/(\d+) Attack/), 0);
+						current.def = $u.setContent(tStr.regex(/(\d+) Defense/), 0);
+						current.api = (current.atk + (current.def * 0.7)).dp(2);
+						current.dpi = (current.def + (current.atk * 0.7)).dp(2);
+						current.mpi = ((current.api + current.dpi) / 2).dp(2);
+					} else {
+						con.warn("No atk/def found for", current.name);
+					}
+
+					tempDiv = $j("strong[class='gold']", row);
+					if ($u.hasContent(tempDiv) && tempDiv.length === 1) {
+						current.cost = $u.setContent(tempDiv.text(), '0').numberOnly();
+					} else {
+						con.log(4, "No cost found for", current.name);
+					}
+
+					tStr = row.children().eq(3).text().trim().innerTrim();
+					if ($u.hasContent(tStr)) {
+						current.owned = $u.setContent(tStr.regex(/Owned: (\d+)/), 0);
+						current.hourly = current.owned * current.upkeep;
+					} else {
+						con.warn("No number owned found for", current.name);
+					}
+
+					stats.setRecord(current);
+				});
+
+			default :
+				break;
+			}
+        } catch (err) {
+            con.error("ERROR in stats.checkResults: " + err.stack);
+            return false;
+        }
+    };
+
+    stats.getCount = function(image) {
+        return $u.setContent(stats.getRecord(image).owned, 0);
+    };
+
+    stats.dashboard = function() {
+        try {
+            /*-------------------------------------------------------------------------------------\
+                Next we build the HTML to be included into the 'soldiers', 'item' and 'magic' div.
+                We set our table and then build the header row.
+                \-------------------------------------------------------------------------------------*/
+            if (config.getItem('DBDisplay', '') === 'Town Stats' && session.getItem("townDashUpdate", true)) {
+                var headers = ['Name', 'Type', 'Own', 'Atk', 'Def', 'API', 'DPI', 'MPI', 'Cost', 'Upkeep', 'Hourly'],
+                    values = ['name', 'type', 'owned', 'atk', 'def', 'api', 'dpi', 'mpi', 'cost', 'upkeep', 'hourly'],
+                    pp = 0,
+                    i = 0,
+                    it = 0,
+                    len = 0,
+                    len1 = 0,
+                    len2 = 0,
+                    str = '',
+                    num = 0,
+                    header = {
+                        text: '',
+                        color: '',
+                        bgcolor: '',
+                        id: '',
+                        title: '',
+                        width: ''
+                    },
+                    head = '',
+                    body = '',
+                    row = '';
+
+				for (pp = 0, len1 = headers.length; pp < len1; pp += 1) {
+
+					header = {
+						text: headers[pp],
+						color: '',
+						id: '',
+						title: '',
+						width: ''
+					};
+
+					switch (headers[pp]) {
+					case 'Name':
+						header.width = '30%';
+						break;
+					case 'Type':
+						header.width = '7%';
+						break;
+					case 'Own':
+						header.width = '6%';
+						break;
+					case 'Atk':
+						header.width = '6%';
+						break;
+					case 'Def':
+						header.width = '6%';
+						break;
+					case 'API':
+						header.width = '6%';
+						break;
+					case 'DPI':
+						header.width = '6%';
+						break;
+					case 'MPI':
+						header.width = '6%';
+						break;
+					case 'Cost':
+						header.width = '9%';
+						break;
+					case 'Upkeep':
+						header.width = '9%';
+						break;
+					case 'Hourly':
+						header.width = '9%';
+						break;
+					default:
+					}
+
+					head += caap.makeTh(header);
+				}
+
+				head = caap.makeTr(head);
+				for (it = 0, len1 = stats.records.length; it < len1; it += 1) {
+					row = "";
+					for (pp = 0, len2 = values.length; pp < len2; pp += 1) {
+
+						if ($u.isNaN(stats.records[it][values[pp]]) || !$u.hasContent(stats.records[it][values[pp]])) {
+							str = $u.setContent(stats.records[it][values[pp]], '');
+						} else {
+							num = stats.records[it][values[pp]];
+							str = $u.hasContent(num) && (values[pp] === 'cost' || values[pp] === 'upkeep' || values[pp] === 'hourly') ? "$" + num.SI() : num.addCommas();
+						}
+
+						row += caap.makeTd({
+							text: str,
+							color: '',
+							id: '',
+							title: ''
+						});
+					}
+
+					body += caap.makeTr(row);
+				}
+
+				$j("#caap_Town_Stats", caap.caapTopObject).html(
+				$j(caap.makeTable('Town', head, body)).dataTable({
+					"bAutoWidth": false,
+					"bFilter": false,
+					"bJQueryUI": false,
+					"bInfo": false,
+					"bLengthChange": false,
+					"bPaginate": false,
+					"bProcessing": false,
+					"bStateSave": true,
+					"bSortClasses": false
+				}));
+
+				session.setItem("townDashUpdate", false);
+            }
+
+            return true;
+        } catch (err) {
+            con.error("ERROR in stats.dashboard: " + err);
+            return false;
+        }
+    };
+
+}());


### PR DESCRIPTION
Generals
Fix for idle general looping
Fix for pausing when trying to load a loudout that isn't set
Fix for saving loadout settings when loadouts are reset

Battle
Standardize all battle records to be stored in the battle.records. History is done for different effective attacks, either by using GB powers like Divine Favour or Confuse or by invading with different army sizes. Based on the success or failure, minimum and maximum effective defenses will be calculated for better win chance estimates. Before, if you succeeded at a Confusing a target, and then tried to duel the same target, CAAP would give you the same odds as if you never confused the target. Now it uses that information to give a better estimate of your chance to beat it.

GB
Fix for Rogue smokebomb attack
Streamlined DOM check for GB reviews, to reduce scanning time per page down to a third.
Remove user ID log spam, now that battle results are stored in the battle records, where they should be
Enable calculation for Divine Favour and Enrage based on % increase to stats

Other
Daylight savings offset changed for summer
Fix MyGuildId bug by moving the IDs into the caap.stats object
Records now strictly enforce templates, and fields not included in the templates are deleted instead of saved.
Added action for Essence work back into action list