### PR TITLE
Google Sheets and Damage-based GB Target Selection

### DIFF
--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -3908,7 +3908,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             return false;
         }
     };
-    caap.numberBoxListener = function (e) {
+ 
+	caap.numberBoxListener = function (e) {
         try {
             var idName = e.target.id.stripCaap(),
                 number = null,
@@ -4719,8 +4720,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             CheckResultsFunction: 'checkResults_army'
         },
         'keep': {
-            signaturePic: 'tab_stats_on.gif',
-            CheckResultsFunction: 'checkResults_keep'
+            signaturePic: 'tab_stats_on.gif'
         },
         'oracle': {
             signaturePic: 'oracle_on.gif'
@@ -4883,8 +4883,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             CheckResultsFunction : 'checkResults_arenaBattle'
         },
         'player_loadouts' : {
-            signatureId : 'load_top2.jpg',
-            CheckResultsFunction : 'checkResults_loadouts'
+            signatureId : 'load_top2.jpg'
         }
     };
 
@@ -4909,8 +4908,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             if (config.getItem("enableTitles", true)) {
                 spreadsheet.doTitles();
             }
-
-            general.Shrink();
 
             var pageUrl = session.getItem('clickUrl', ''),
                 page2 = $u.setContent(pageUrl, 'none').basename(".php"),
@@ -4956,11 +4953,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             }
             
             session.setItem('page', page);
-            general.getLoadouts();
-            general.getEquippedStats();
-
 			worker.list.forEach(worker.checkResults);
-			worker.list.forEach(worker.checkSave);
 			
             if ($u.hasContent(caap.pageList[page])) {
                 con.log(3, 'caap.checkResultsTop caap.resultsText', caap.resultsText);
@@ -4976,17 +4969,14 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 con.log(2, 'No results check defined for', page);
             }
 
+			worker.list.forEach(worker.checkSave);
+			
             // Information updates
             caap.updateDashboard();
             caap.setNextLevelMessage();
             caap.setDivContent('demipoint_mess', !battle.demisPointsToDo('set') ? 'Daily Demi Points: off' : battle.demisPointsToDo('left') ? 'Daily Demi Points in progress' : 'Daily Demi Points done');
             caap.setDivContent('essenceScan_mess', schedule.check('newEssenceListTimer') ? 'Essence Scan = none' : 'Next Scan: ' + $u.setContent(caap.displayTime('newEssenceListTimer'), "Unknown"));
             caap.setDivContent('feats_mess', schedule.check('festivalBlessTimer') ? 'Feat = none' : 'Next Feat: ' + $u.setContent(caap.displayTime('festivalBlessTimer'), "Unknown"));
-            if ($u.hasContent(general.List) && general.List.length <= 2) {
-                schedule.setItem("generals", 0);
-                schedule.setItem("allGenerals", 0);
-                caap.checkGenerals();
-            }
 
             return true;
         } catch (err) {
@@ -5043,498 +5033,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         } catch (err) {
             con.error("ERROR in getStatusNumbers: " + err, text, record);
             return undefined;
-        }
-    };
-
-    caap.checkResults_keep = function () {
-        try {
-            var attrDiv = $j("#app_body #keepAltStats"),
-                statsTB = $j("#app_body div[style*='keep_cont_treasure.jpg'] div:nth-child(3)>div>div>div>div"),
-                //keepTable1 = $j("#app_body .keepTable1 tr"),
-                statCont = $j("#app_body div[style*='keep_bgv2.jpg']>div>div>div"),
-				recordsTxt = $j(),
-				args = [],
-                backgroundDiv = $j(),
-                tempDiv = $j(),
-                temp,
-                row,
-                head,
-                body;
-
-            if ($u.hasContent(attrDiv)) {
-				con.log(2, "Getting new values from player keep");
-				// rank
-				tempDiv = $j("#app_body img[src*='gif/rank']");
-				if ($u.hasContent(tempDiv)) {
-					stats.rank.battle = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
-				} else {
-					con.warn('Using stored rank.');
-				}
-
-				// PlayerName
-				tempDiv = $j("#app_body div[style*='keep_top.jpg'] div").first();
-				if ($u.hasContent(tempDiv)) {
-					stats.PlayerName = tempDiv.text().trim();
-					//con.log(1, stats.PlayerName);
-				} else {
-					con.warn('Using stored PlayerName.');
-				}
-
-				// FBID
-				tempDiv = $j("#app_body a[href*='keep.php?user=']");
-				if ($u.hasContent(tempDiv)) {
-					stats.FBID = tempDiv.attr("href").basename().regex(/(\d+)/);
-					//con.log(1, stats.FBID);
-				} else {
-					con.warn('Using stored PlayerName.');
-				}
-
-				// war rank
-				if (stats.level >= 100) {
-					tempDiv = $j("#app_body img[src*='war_rank_']");
-					if ($u.hasContent(tempDiv)) {
-						stats.rank.war = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
-					} else {
-						con.warn('Using stored warRank.');
-					}
-				}
-                // conquest rank
-                if (stats.level >= 100) {
-                    tempDiv = $j("#app_body img[src*='conquest_rank_']");
-                    if ($u.hasContent(tempDiv)) {
-                        stats.rank.conquest = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
-                    } else {
-                        con.warn('Using stored conquestRank.');
-                    }
-                }
-
-				if ($u.hasContent(statCont) && statCont.length >= 6) {
-					if (stats.level >= 10) {
-						// Attack
-						tempDiv = statCont.eq(2);
-						if ($u.hasContent(tempDiv)) {
-							stats.attack = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
-							stats.bonus.attack = $u.setContent($u.setContent(tempDiv.text(), '').regex(/\(\+(\d+)\)/), 0);
-							//con.log(2,'KEEP Attack', stats.attack, stats.attackbonus);
-						} else {
-							con.warn('Using stored attack value.');
-						}
-
-						// Defense
-						tempDiv = statCont.eq(3);
-						if ($u.hasContent(tempDiv)) {
-							stats.defense = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
-							stats.bonus.defense = $u.setContent($u.setContent(tempDiv.text(), '').regex(/\(\+(\d+)\)/), 0);
-							//con.log(2,'KEEP Defense', stats.defense, stats.defensebonus);
-						} else {
-							con.warn('Using stored defense value.');
-						}
-					}
-
-                    // Health
-                    tempDiv = statCont.eq(4);
-                    if ($u.hasContent(tempDiv)) {
-                        stats.health.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
-                        
-                    } else {
-                        con.warn('Unable to find unadjusted Health value.');
-                    }
-                    
-                    // Energy
-                    tempDiv = statCont.eq(0);
-                    if ($u.hasContent(tempDiv)) {
-                        stats.energy.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
-                    } else {
-                        con.warn('Unable to find unadjusted Energy value.');
-                    }
-
-                    // Stamina
-                    tempDiv = statCont.eq(1);
-                    if ($u.hasContent(tempDiv)) {
-                        stats.stamina.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
-                    } else {
-                        con.warn('Unable to find unadjusted Stamina value.');
-                    }
-                } else {
-                    con.warn("Can't find stats containers! Using stored stats values.");
-                }
-
-				// Check for Gold Stored
-				tempDiv = statsTB.eq(4);
-				if ($u.hasContent(tempDiv)) {
-					stats.gold.bank = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
-					stats.gold.total = stats.gold.bank + stats.gold.cash;
-					tempDiv.attr({
-						title: "Click to copy value to retrieve"
-					}).css({
-						color: "blue",
-						cursor: "pointer"
-					}).on("click", function () {
-						$j("#app_body #getGold").val(stats.gold.bank);
-					});
-				} else {
-					con.warn('Using stored inStore.');
-				}
-
-				// Check for income
-				tempDiv = statsTB.eq(5);
-				if ($u.hasContent(tempDiv)) {
-					stats.gold.income = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
-				} else {
-					con.warn('Using stored income.');
-				}
-
-				// Check for upkeep
-				tempDiv = statsTB.eq(6);
-				if ($u.hasContent(tempDiv)) {
-					stats.gold.upkeep = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
-				} else {
-					con.warn('Using stored upkeep.');
-				}
-
-				// Cash Flow
-				stats.gold.flow = stats.gold.income - stats.gold.upkeep;
-
-				// Energy potions
-				tempDiv = $j("div[title='Energy Potion']").children().eq(1);
-				if ($u.hasContent(tempDiv)) {
-					stats.potions.energy = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
-				} else {
-					stats.potions.energy = 0;
-				}
-
-				// Stamina potions
-				tempDiv = $j("div[title='Stamina Potion']").children().eq(1);
-				if ($u.hasContent(tempDiv)) {
-					stats.potions.stamina = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
-				} else {
-					stats.potions.stamina = 0;
-				}
-
-				// Other stats
-				// Atlantis Open
-				stats.other.atlantis = $u.hasContent(caap.checkForImage("seamonster_map_finished.jpg")) ? true : false;
-
-				recordsTxt = $u.setContent($j("#globalContainer #records_tab").text().trim().innerTrim(), '');
-				args = recordsTxt.match(new RegExp("Quests Completed (\\d+) Battles/Wars Won (\\d+) Battles/Wars Lost (\\d+) Kills (\\d+) Deaths (\\d+)"));
-				if (args && args.length === 6) {
-					stats.other.qc = args[1].numberOnly();
-					stats.other.bww = args[2].numberOnly();
-					stats.other.bwl = args[3].numberOnly();
-					stats.other.te = args[4].numberOnly();
-					stats.other.tee = args[5].numberOnly();
-					//con.log(2, "my stats", args, recordsTxt, stats.other);
-				} else {
-					con.warn("Unable to read quests completed and battle stats", args, recordsTxt);
-				}
-
-				// Win/Loss Ratio (WLR)
-				stats.other.wlr = stats.other.bwl !== 0 ? (stats.other.bww / stats.other.bwl).dp(2) : Infinity;
-				// Enemy Eliminated Ratio/Eliminated (EER)
-				stats.other.eer = stats.other.tee !== 0 ? (stats.other.tee / stats.other.te).dp(2) : Infinity;
-				// Indicators
-				if (stats.level >= 10) {
-					stats.indicators.bsi = ((stats.attack + stats.defense) / stats.level).dp(2);
-					stats.indicators.lsi = ((stats.energy.max + (2 * stats.stamina.max)) / stats.level).dp(2);
-					stats.indicators.sppl = ((stats.energy.max + (2 * stats.stamina.max) + stats.attack + stats.defense + stats.health.max - 122) / stats.level).dp(2);
-					stats.indicators.api = (stats.attack + (stats.defense * 0.7)).dp(0);
-					stats.bonus.api = stats.indicators.api + (stats.bonus.attack + (stats.bonus.defense * 0.7)).dp(0);
-					stats.indicators.dpi = ((stats.defense + (stats.attack * 0.7))).dp(0);
-					stats.bonus.dpi = stats.indicators.dpi + (stats.bonus.defense + (stats.bonus.attack * 0.7)).dp(0);
-					stats.indicators.mpi = (((stats.indicators.api + stats.indicators.dpi) / 2)).dp(0);
-					stats.indicators.mhbeq = ((stats.attack + (2 * stats.stamina.max)) / stats.level).dp(2);
-					if (stats.attack >= stats.defense) {
-						temp = stats.attack / stats.defense;
-						if (temp === stats.attack) {
-							stats.indicators.pvpclass = 'Destroyer';
-						} else if (temp >= 2 && temp < 7.5) {
-							stats.indicators.pvpclass = 'Aggressor';
-						} else if (temp < 2 && temp > 1.01) {
-							stats.indicators.pvpclass = 'Offensive';
-						} else if (temp <= 1.01) {
-							stats.indicators.pvpclass = 'Balanced';
-						}
-					} else {
-						temp = stats.defense / stats.attack;
-						if (temp === stats.defense) {
-							stats.indicators.pvpclass = 'Wall';
-						} else if (temp >= 2 && temp < 7.5) {
-							stats.indicators.pvpclass = 'Paladin';
-						} else if (temp < 2 && temp > 1.01) {
-							stats.indicators.pvpclass = 'Defensive';
-						} else if (temp <= 1.01) {
-							stats.indicators.pvpclass = 'Balanced';
-						}
-					}
-				}
-
-                // added essence totals
-                stats.essence.Attack = parseInt ($j("div[title*='Attack Essence']").siblings()[0].innerText.trim().replace('x', ''), 0);
-                stats.essence.Defense = parseInt ($j("div[title*='Defense Essence']").siblings()[0].innerText.trim().replace('x', ''), 0);
-                stats.essence.Health = parseInt ($j("div[title*='Health Essence']").siblings()[0].innerText.trim().replace('x', ''), 0);
-                stats.essence.Damage = parseInt ($j("div[title*='Damage Essence']").siblings()[0].innerText.trim().replace('x', ''), 0);
-
-                statsFunc.setRecord(stats);
-                if (config.getItem("displayKStats", true)) {
-                    tempDiv = $j("div[style*='keep_top']");
-                    backgroundDiv = $j("div[style*='keep_tabheader']");
-
-					temp = "<div style='background-image:url(\"" + caap.domain.protocol[caap.domain.ptype] +"castleagegame1-a.akamaihd.net/30966/graphics/keep_tabsubheader_mid.jpg\");border:none;padding: 5px 5px 20px 20px;width:715px;font-weight:bold;font-family:Verdana;sans-serif;background-repeat:y-repeat;'>";
-					temp += "<div style='border:1px solid #701919;padding: 5px 5px;width:688px;height:100px;background-color:#d0b682;'>";
-                    row = caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '5%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '10%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '20%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '10%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '20%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '10%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '20%'
-                    });
-
-                    row += caap.makeTh({
-                        text: '&nbsp;',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: '5%'
-                    });
-
-                    head = caap.makeTr(row);
-
-                    row = caap.makeTd({
-                        text: '',
-                        color: '',
-                        id: '',
-                        title: ''
-                    });
-
-                    row += caap.makeTd({
-                        text: 'BSI',
-                        color: '',
-                        id: '',
-                        title: 'Battle Strength Index'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.bsi,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'LSI',
-                        color: '',
-                        id: '',
-                        title: 'Leveling Speed Index'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.lsi,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'SPPL',
-                        color: '',
-                        id: '',
-                        title: 'Skill Points Per Level (More accurate than SPAEQ)'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.sppl,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    body = caap.makeTr(row);
-
-                    row = caap.makeTd({
-                        text: '',
-                        color: '',
-                        id: '',
-                        title: ''
-                    });
-
-                    row += caap.makeTd({
-                        text: 'API',
-                        color: '',
-                        id: '',
-                        title: 'Attack Power Index'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.api,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'DPI',
-                        color: '',
-                        id: '',
-                        title: 'Defense Power Index'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.dpi,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'MPI',
-                        color: '',
-                        id: '',
-                        title: 'Mean Power Index'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.mpi,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    body += caap.makeTr(row);
-
-                    row = caap.makeTd({
-                        text: '',
-                        color: '',
-                        id: '',
-                        title: ''
-                    });
-
-                    row += caap.makeTd({
-                        text: 'MHBEQ',
-                        color: '',
-                        id: '',
-                        title: 'Monster Hunting Build Effective Quotent'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.mhbeq,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'Build',
-                        color: '',
-                        id: '',
-                        title: 'Character build type'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.build,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: 'PvP Class',
-                        color: '',
-                        id: '',
-                        title: 'Player vs. Player character class'
-                    }, "font-size:14px;");
-
-                    row += caap.makeTd({
-                        text: stats.indicators.pvpclass,
-                        color: '',
-                        id: '',
-                        title: ''
-                    }, "font-size:14px;");
-
-                    body += caap.makeTr(row);
-
-                    temp += caap.makeTable("keepstats", head, body, "Statistics", "font-size:16px;");
-                    temp += "</div></div>";
-                    tempDiv.after(temp);
-                } else {
-                    tempDiv = $j(".keep_stat_title_inc", attrDiv);
-                    tempDiv = $u.hasContent(tempDiv) ? tempDiv.html($u.setContent(tempDiv.html(), '').trim() + ", <span style='white-space: nowrap;'>BSI: " +
-                        stats.indicators.bsi + " LSI: " + stats.indicators.lsi + "</span>") : tempDiv;
-                }
-            } else {
-                tempDiv = $j("#app_body a[href*='keep.php?user=']");
-                if ($u.hasContent(tempDiv)) {
-                    con.log(2, "On another player's keep", $u.setContent($u.setContent(tempDiv.attr("href"), '').basename().regex(/(\d+)/), 0));
-                } else {
-                    con.warn("Attribute section not found and not identified as another player's keep!");
-                }
-            }
-
-            /*
-            if (config.getItem("enableKeepShrink", true)) {
-                $j("#app_body div[class*='statUnit'] img").attr("style", "height: 45px, width: 45px;").not("#app_body div[class*='statUnit'] img[alt='Stamina Potion'],img[alt='Energy Potion']").parent().parent().attr("style", "height: 45px, width: 45px;");
-            }
-            */
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in checkResults_keep: " + err.stack);
-            return false;
         }
     };
 
@@ -6556,10 +6054,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 }
             }
 
-            if (general.quickSwitch) {
-//                general.getEquippedStats();
-            }
-
             // Buy quest requires popup
             itemBuyPopUp = $j('#globalContainer form[id*="itemBuy"]');
             costToBuy = 0;
@@ -6686,7 +6180,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 if (general.Select('SubQuestGeneral')) {
                     return true;
                 }
-            } else if (questGeneral && questGeneral !== general.getCurrentGeneral()) {
+            } else if (questGeneral && questGeneral !== general.current) {
                 if (general.LevelUpCheck("QuestGeneral")) {
                     if (general.Select('LevelUpGeneral')) {
                         return true;
@@ -8558,14 +8052,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             con.error("ERROR in checkResults_conquestMist: " + err.stack);
             return false;
         }
-    };
-
-    caap.doArenaBattle = function() {
-        return arena.battle();
-    };
-
-    caap.checkResults_arenaBattle = function() {
-        arena.checkResults();
     };
 
     caap.checkResults_guildTradeMarket = function () {

--- a/Chrome/unpacked/js/head.js
+++ b/Chrome/unpacked/js/head.js
@@ -86,6 +86,12 @@ Array.prototype.addToList = function(v) {
 	return this;
 };
 
+Array.prototype.sum = function() {
+	return this.reduce(function(a,b) {
+		return a+b;
+	});
+}
+
 Array.prototype.removeFromList = function(v) {
 	var i = this.indexOf(v);
 	if (i > -1) {
@@ -117,9 +123,12 @@ Array.prototype.deleteObjs = function(f, v) {
 };
 
 Array.prototype.listMatch = function(r) {
-	return this.reduce( function(p, c) {
-		return $u.setContent(p, c.regex(r));
-	}, null);
+	var m = false;
+	this.some( function(c) {
+		m = c.regex(r); 
+		return m;
+	});
+	return m;
 };
 
 String.prototype.parseTimer = function() {

--- a/Chrome/unpacked/js/options.js
+++ b/Chrome/unpacked/js/options.js
@@ -1,37 +1,30 @@
 var submitButton = document.querySelector('button.submit');
-var email = document.querySelector('#caWeb3Email');
-var password = document.querySelector('#caWeb3Password');
+var list = ['gsheet', 'salt', 'email', 'password'];
+list.forEach( function(e) {
+	window[e] = document.querySelector('#caweb3' + e);
+});
 
 loadChanges();
 
 submitButton.addEventListener('click', saveChanges);
 
 function saveChanges() {
-	var caweb3email = email.value;
-	var caweb3password = password.value;
-  
-	chrome.runtime.sendMessage({method: "setLocalStorage", key: "caweb3email", value: caweb3email}, function(response) {
-		console.log(response.data);
-		message('Settings saved');
-	});
-	chrome.runtime.sendMessage({method: "setLocalStorage", key: "caweb3password", value: caweb3password}, function(response) {
-		console.log(response.data);
-		message('Settings saved');
+	list.forEach( function(e) {
+		chrome.runtime.sendMessage({method: "setLocalStorage", key: "caweb3" + e, value: window[e].value}, function(response) {
+			console.log(response.data);
+			message('Settings saved');
+		});
 	});
 }
 
 function loadChanges() {
-	chrome.runtime.sendMessage({method: "getLocalStorage", key: "caweb3email"}, function(response) {
-		if (response.data && response.data!='error') {
-			email.value=response.data;
-			message('Loaded saved settings.');
-		}
-	});
-	chrome.runtime.sendMessage({method: "getLocalStorage", key: "caweb3password"}, function(response) {
-		if (response.data && response.data!='error') {
-			password.value=response.data;
-			message('Loaded saved settings.');
-		}
+	list.forEach( function(e) {
+		chrome.runtime.sendMessage({method: "getLocalStorage", key: "caweb3" + e}, function(response) {
+			if (response.data && response.data!='error') {
+				window[e].value = response.data;
+				message('Loaded saved settings.');
+			}
+		});
 	});
 }
 

--- a/Chrome/unpacked/js/worker.js
+++ b/Chrome/unpacked/js/worker.js
@@ -72,7 +72,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					Object.keys(r).forEach( function(e) {
 						if (!Object.keys(newR).hasIndexOf(e)) {
 							undefinedKeyList = undefinedKeyList.addToList(e);
-							delete r.e;
+							delete r[e];
 						}
 					});
 				});
@@ -112,6 +112,30 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					r[wO.recordIndex] = n;
 					r.newRecord = true;
 					return r;
+				}
+			};
+
+			wO.getRecordByField = function(f, v) {
+				if (!$u.isString(f) ) {
+					con.error(wO.name + ' field is not string: ' + f);
+					return false;
+				}
+				var flat = wO.records.flatten(f),
+					i = -1;
+				if ($u.isRegExp(v)) {
+					flat.some( function(e, ii) {
+						i = e.match(v) ? ii : -1;
+						return i >= 0;
+					});
+				} else {
+					i = flat.indexOf(v);
+				}
+				
+				if (i >= 0) {
+					wO.records[i].newRecord = false;
+					return $j.extend(true, {}, new wO.record().data, wO.records[i]);
+				} else {
+					return false;
 				}
 			};
 

--- a/Chrome/unpacked/js/worker_battle.js
+++ b/Chrome/unpacked/js/worker_battle.js
@@ -382,7 +382,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					tempText = '',
 					tNum = 0,
 					warWinLoseImg = '',
-					currentGeneral = general.getCurrentGeneral(),
 					result = {};
 
 				// Check demi points
@@ -957,7 +956,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
                     tempRecord.name = $u.setContent(levelm[1], '').trim();
                     tempRecord.rank = $u.setContent(levelm[2], '').parseInt();
-                    tempRecord.rankStr = battle.battleRankTable[tempRecord.rank];
                     tempRecord.level = $u.setContent(levelm[4], '').parseInt();
                     tempRecord.army = $u.setContent(levelm[6], '').parseInt();
                 } else {
@@ -1027,10 +1025,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
                     tempRecord.name = $u.setContent(levelm[1], '').trim();
                     tempRecord.level = $u.setContent(levelm[2], '').parseInt();
-                    tempRecord.rankStr = $u.setContent(levelm[3], '').trim();
                     tempRecord.rank = $u.setContent(levelm[4], '').parseInt();
                     if (battle.battles.Freshmeat.warLevel) {
-                        tempRecord.warRankStr = $u.setContent(levelm[5], '').trim();
                         tempRecord.warRank = $u.setContent(levelm[6], '').parseInt();
                         tempRecord.army = $u.setContent(levelm[7], '').parseInt();
                     } else {
@@ -1038,7 +1034,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                     }
                 }
 				
-				con.log(3, 'Battle target stats:', tempRecord.name, tempRecord.level, tempRecord.rankStr, tempRecord.rank, tempRecord.army);
+				con.log(3, 'Battle target stats:', tempRecord.name, tempRecord.level, tempRecord.rank, tempRecord.army);
 
                 levelMultiplier = stats.level / (tempRecord.level > 0 ? tempRecord.level : 1);
                 armyRatio = ARBase * levelMultiplier;

--- a/Chrome/unpacked/js/worker_chores.js
+++ b/Chrome/unpacked/js/worker_chores.js
@@ -23,7 +23,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				schedule.setItem('page_' + url, Date.now());
 			}
         } catch (err) {
-            con.error("ERROR in chores.heal: " + err.stack);
+            con.error("ERROR in chores.checkResults: " + err.stack);
             return false;
         }
     };
@@ -706,9 +706,10 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
 	worker.addPageCheck({page : 'keep', hours : 1});
 
-    chores.checkPages = function(page) {
+    chores.checkPages = function(page, value) {
         try {
-			var list = $u.isString(page) ? [{'page' : page}] : worker.pagesList,
+			var list = $u.isDefined(value) ? worker.pagesList.filterByField(page, value) 
+				: $u.isString(page) ? [{page : page}] : worker.pagesList,
 				hours = 0;
 			return list.some( function(o) {
 				if (o.config && !config.getItem(o.config, false)) {

--- a/Chrome/unpacked/js/worker_conquest.js
+++ b/Chrome/unpacked/js/worker_conquest.js
@@ -1451,12 +1451,12 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 guildButtonLevel = Math.min (Math.floor ((guildRecord[essence + 'Max'] - guildRecord[essence]) / 200), 4);
 
                     // update the essence totals
-                stats.essence.Attack = parseInt ($j("div[title*='Attack Essence']")[0].title.replace('Attack Essence - ', ''), 10);
-                stats.essence.Defense = parseInt ($j("div[title*='Defense Essence']")[0].title.replace('Defense Essence - ', ''), 10);
-                stats.essence.Health = parseInt ($j("div[title*='Health Essence']")[0].title.replace('Health Essence - ', ''), 10);
-                stats.essence.Damage = parseInt ($j("div[title*='Damage Essence']")[0].title.replace('Damage Essence - ', ''), 10);
+                stats.essence.attack = parseInt ($j("div[title*='Attack Essence']")[0].title.replace('Attack Essence - ', ''), 10);
+                stats.essence.defense = parseInt ($j("div[title*='Defense Essence']")[0].title.replace('Defense Essence - ', ''), 10);
+                stats.essence.health = parseInt ($j("div[title*='Health Essence']")[0].title.replace('Health Essence - ', ''), 10);
+                stats.essence.damage = parseInt ($j("div[title*='Damage Essence']")[0].title.replace('Damage Essence - ', ''), 10);
 
-                runeButtonLevel = Math.min (Math.floor ((stats.essence[essence] - essenceValue) / 200), config.getItem('maxEssenceTrade'));
+                runeButtonLevel = Math.min (Math.floor ((stats.essence[essence.toLowerCase()] - essenceValue) / 200), config.getItem('maxEssenceTrade'));
                 buttonLevel = Math.min (Math.min (guildButtonLevel, energyButtonLevel), runeButtonLevel);
 
                 if (buttonLevel >= 1) {

--- a/Chrome/unpacked/js/worker_feed.js
+++ b/Chrome/unpacked/js/worker_feed.js
@@ -37,7 +37,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 				
 			return true;
 		} catch (err) {
-			con.error("ERROR in feed.deleteExpired: " + err.stack);
+			con.error("ERROR in feed.init: " + err.stack);
 			return false;
 		}
 	};
@@ -125,7 +125,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 				},
 				result,
 				charStats = stats.character,
-				currentGeneralObj = general.getRecord(general.getCurrentGeneral()),
+				currentGeneralObj = general.getRecord(general.current),
 				joinable = function(cM) {
 					return cM.join && cM.status == 'Join';
 				},

--- a/Chrome/unpacked/js/worker_gb.js
+++ b/Chrome/unpacked/js/worker_gb.js
@@ -949,10 +949,10 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				tRecord = gb.getRecord('gb10'),
 				configSet = false;
 				
-			if (schedule.since(fRecord.startTime, -15 * 60) && !schedule.since(fRecord.startTime, -5 * 60)) {
+			if (schedule.since(fRecord.startTime, -11 * 60) && !schedule.since(fRecord.startTime, -1 * 60)) {
 				stats.priorityGeneral = config.getItem('100v100_ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('100v100_ClassGeneral','Use Current');
 			}
-			if (stats.priorityGeneral == 'Use Current' && schedule.since(tRecord.startTime, -15 * 60) && !schedule.since(tRecord.startTime, -5 * 60)) {
+			if (stats.priorityGeneral == 'Use Current' && schedule.since(tRecord.startTime, -11 * 60) && !schedule.since(tRecord.startTime, -1 * 60)) {
 				stats.priorityGeneral = config.getItem('10v10_ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('10v10_ClassGeneral','Use Current');
 			}
 			if (stats.priorityGeneral == 'Use Current' && gRecord.state == 'Auto-match') {

--- a/Chrome/unpacked/js/worker_gb.js
+++ b/Chrome/unpacked/js/worker_gb.js
@@ -35,6 +35,8 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 			simtis: false, // someone in my tower is stunned
 			firstScanDone: false,
 			burn: false,
+			heal:0,
+			healGen: [],
 			t: { score: 0,
 				tokens: 1 },
 			tokens: 10,
@@ -57,207 +59,240 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 
     gb.member = function() {
         this.data = {
-            'tower': 0,
-            'position': 0,
-            'target_id': 0,
-            'name': '',
-            'level': 0,
-            'mclass': '',
-            'healthNum': 0,
-            'healthMax': 0,
-            'status': '',
-            'percent': 0,
-			'battlePoints' : 0,
-			'points' : 0,
-			'scores' : {},
-			'metrics' : {}
+            tower: 0,
+            position: 0,
+            target_id: 0,
+			isMe : false,
+            name: '',
+            level: 0,
+            mclass: '',
+            healthNum: 0,
+            healthMax: 0,
+            status: '',
+            percent: 0,
+			battlePoints: 0,
+			points: 0,
+			scores: {},
+			metrics: {}
         };
     };
 
 	gb.towerRecord = function () {
 		this.data = {
-			'players' : 0,
-			'clerics' : 0,
-			'actives' : 0,
-			'AC' : 0,
-			'seal' : {
-				'stunned' : {
-					'score' : 0
+			players: 0,
+			clerics: 0,
+			actives: 0,
+			AC: 0,
+			seal: {
+				stunned: {
+					score: 0
 				},
-				'unstunned' : {
-					'score' : 0
+				unstunned: {
+					score: 0
 				}
 			},
-			'normal' : {
-				'stunned' : {
-					'score' : 0
+			normal: {
+				stunned: {
+					score: 0
 				},
-				'unstunned' : {
-					'score' : 0
+				unstunned: {
+					score: 0
 				}
 			},
-			'healthNum' : 0,
-			'healthMax' : 0,
-			'damage' : 0,
-			'life' : 0
+			healthNum: 0,
+			healthMax: 0,
+			damage: 0,
+			life: 0
 		};
 	};
 	
     gb.wlRecord = function() {
         this.data = {
-            'name': '',
-            'duel': {
-				'wins' : 0,
-				'losses' : 0
+            name: '',
+            duel: {
+				wins: 0,
+				losses: 0
 			},
-            'poly': {
-				'wins' : 0,
-				'losses' : 0
+            poly: {
+				wins: 0,
+				losses: 0
 			},
-            'confuse': {
-				'wins' : 0,
-				'losses' : 0
+            confuse: {
+				wins: 0,
+				losses: 0
 			},
-            'heal': {
-				'wins' : 0,
-				'losses' : 0
+            heal: {
+				wins: 0,
+				losses: 0
 			},
-            'guild': '',
-            'guildID': '',
-            'level': 0,
-            'health': 0,
-			'class' : ''
+            guild: '',
+            guildID: '',
+            level: 0,
+            health: 0,
+			class: ''
         };
     };
 
     gb.me = function() {
         this.data = {
-            'name': '',
-            'level': 0,
-            'mclass': '',
-            'healthNum': 0,
-            'healthMax': 0,
-            'status': '',
-            'percent': 0
+            name: '',
+            level: 0,
+            mclass: '',
+            healthNum: 0,
+            healthMax: 0,
+            status: '',
+            percent: 0
         };
     };
 
 	gb.gb100 = {
-		'name' : '100v100', // Used for user facing text
-		'label' : 'gb100', // Used for internal naming 'guild_battle_scoring'
-		'stamina' : 20,
-		'enterButton' : 'guild_enter_battle_button2.gif',
-		'infoDiv' : 'fest_guild_battle',
-		'waitHours' : 3.9,
-		'collectHours' : 1.5,
-		'minHealth' : 200,
+		name: '100v100', // Used for user facing text
+		label: 'gb100', // Used for internal naming 'guild_battle_scoring'
+		stamina: 20,
+		enterButton: 'guild_enter_battle_button2.gif',
+		infoDiv: 'fest_guild_battle',
+		waitHours: 3.9,
+		collectHours: 1.5,
+		minHealth: 200,
 		scoring : 'guild_battle_scoring',
-		'basePath' : 'tenxten_gb_formation,hundred_battle,clickimg:sort_btn_joinbattle.gif,hundred_battle_view'
+		basePath: 'tenxten_gb_formation,hundred_battle,clickimg:sort_btn_joinbattle.gif,hundred_battle_view'
 	};
 		
 	gb.gbClassic = {
-		'name' : 'Classic',
-		'label' : 'gbClassic',
-		'stamina' : 20,
-		'enterButton' : 'guild_enter_battle_button2.gif',
-		'infoDiv' : 'guild_achievement',
-		'waitHours' : 8.9,
-		'collectHours' : 8.9,
-		'minHealth' : 1,
+		name: 'Classic',
+		label: 'gbClassic',
+		stamina: 20,
+		enterButton: 'guild_enter_battle_button2.gif',
+		infoDiv: 'guild_achievement',
+		waitHours: 8.9,
+		collectHours: 8.9,
+		minHealth: 1,
 		scoring : 'guild_battle_scoring',
-		'basePath' : 'tenxten_gb_formation,guildv2_battle,clickimg:sort_btn_joinbattle.gif,guild_battle'
+		basePath: 'tenxten_gb_formation,guildv2_battle,clickimg:sort_btn_joinbattle.gif,guild_battle'
 	};
 		
 	gb.gb10 = {
-		'name' : '10v10',
-		'label' : 'gb10',
-		'stamina' : 10,
-		'enterButton' : 'guild_enter_battle_button3.gif',
-		'infoDiv' : 'guild_10v10',
-		'waitHours' : 3.9,
-		'collectHours' : 1.5,
-		'minHealth' : 200,
+		name: '10v10',
+		label: 'gb10',
+		stamina: 10,
+		enterButton: 'guild_enter_battle_button3.gif',
+		infoDiv: 'guild_10v10',
+		waitHours: 3.9,
+		collectHours: 1.5,
+		minHealth: 200,
 		scoring : 'guild_battle_scoring',
-		'basePath' : 'tenxten_gb_formation,clickjq:.team_content:visible input[src*="fb_guild_btn_joinbattle_small.gif"],ten_battle'
+		basePath: 'tenxten_gb_formation,clickjq:.team_content:visible input[src*="fb_guild_btn_joinbattle_small.gif"],ten_battle'
 	};
 	
-	gb.enemy = {
-		'mage' : [
-			{'name': 'mduel',
-			'base' : 'duel',
-			'image' : 'attack'},
-			{'name': 'fireball',
-			'tokens' : 2,
-			'base' : 'duel',
-			'image' : 'fireball'},
-			{'name': 'enrage',
-			'tokens' : 2,
-			'base' : 'duel',
-			'image' : 'enrage'},
-			{'name': 'poly',
-			'base' : 'poly',
-			'image' : 'polymoprh'},
-			{'name': 'confuse',
-			'base' : 'confuse'}
+	gb.s = function(t, r) {
+		return parseFloat($u.setContent(t.regex(r), '0'));
+	};
+	
+	gb.enemy = { // need to adjust r100 levels. 1000 for damage?
+		mage: [   
+			{name: 'fireball', tokens: 2, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (splash + h.map( function(p, i) {
+					return Math.min(p, Math.floor(base / [1, 2, 2, 4, 4][i]));
+				}).sum() / 2));
+			}},
+			{name: 'enrage', tokens: 2, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (splash + Math.min(h[0], base)) / 2);
+			}},
+			{name: 'poly', image: 'polymoprh', score: function(fR, mR, h, splash, base, special) {
+				return mR.winChance;
+			}},
+			{name: 'confuse', score: function(fR, mR, h, splash, base, special) {
+				return mR.winChance;
+			}},
+			// Put duel last for mage, so that Dashboard winchance shows duel chance, not poly or confuse
+			{name: 'mduel',	image: 'attack', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (splash + Math.min(h[0], base)));
+			}}
 		],
-		'rogue' : [
-			{'name': 'rduel',
-			'base' : 'duel',
-			'image' : 'attack'},
-			{'name': 'intimidate',
-			'tokens' : 2,
-			'base' : 'duel'},
-			{'name': 'poison', 
-			'base' : 'duel'}
+		rogue: [
+			{name: 'rduel', image: 'attack', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance * (Math.min(h[0], base) + 100 + Math.floor(stats.rune.damage / 5) + gb.s(special,/([\d\.]+) Damage as Rogue/)));
+			}},
+			{name: 'intimidate', tokens: 2, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance * (Math.min(h[0], base) + Math.floor(stats.rune.damage / 5) + gb.s(special,/([\d\.]+) Damage as Rogue/) / 2));
+			}},
+			{name: 'poison', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance * (Math.min(h[0], base) + Math.floor(stats.rune.damage / 5) 
+				+ $u.setContent(special.regex(/([\d\.]+) Damage as Rogue/), '0').parseInt()
+				+ (55 + gb.s(special,/([\d\.]+) Damage and \+[\d\.]+ Duration to Poison/))
+				* (5 + gb.s(special,/[\d\.]+ Damage and \+([\d\.]+) Duration to Poison/))));
+			}}
 		],
-		'warrior' : [
-			{'name': 'wduel',
-			'base' : 'duel',
-			'image' : 'attack'},
-			{'name': 'whirlwind',
-			'base' : 'duel'}
+		warrior: [
+			{name: 'whirlwind', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (h.map( function(p, i) {
+					return Math.min(p, Math.floor(base * [1, 0.86, 0.86, 0, 0][i]));
+				}).sum()));
+			}},
+			{name: 'wduel', image: 'attack', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * Math.min(h[0], base));
+			}}
 		],
-		'cleric' : [
-			{'name': 'cduel',
-			'base' : 'duel',
-			'image' : 'attack'},
-			{'name' : 'divine_favor',
-			'tokens' : 2,
-			'base' : 'duel'}
-
+		cleric: [
+			{name: 'cduel', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (splash + Math.min(h[0], base)));
+			}},
+			{name: 'divine_favor', tokens: 2, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.winChance / 100 * (splash + Math.min(h[0], base)) / 2);
+			}}
 		]
 	};
 
 	gb.your = {
-		'mage' : [],
-		'rogue' : [
-			{'name': 'smokebomb',
-			'self': false,
-			'base' : 'level',
-			image : 'rogue_smoke'}
+		mage: [
+			{name: 'swap', score: function(fR, mR, h, splash, base, special) {
+				return 100 - fR.life;
+			}}
+		],
+		rogue: [
+			{name: 'smokebomb', self: false, image : 'rogue_smoke', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'swap', score: function(fR, mR, h, splash, base, special) {
+				return 100 - fR.life;
+			}}
 		],
 		warrior: [
-			{name: 'guardian',
-			self: false,
-			base: 'level'},
-			{name: 'sentinel',
-			base: 'level'}
+			{name: 'guardian', self: false, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'sentinel', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'swap', score: function(fR, mR, h, splash, base, special) {
+				return 100 - fR.life;
+			}}
 		],
 		cleric: [
-			{name: 'revive',
-			base: 'rhealth'},
-			{name: 'heal',
-			base: 'damage',
-			image: 'cleric_heal'},
-			{name: 'mass_heal',
-			tokens: 2,
-			base: 'damage'},
-			{name: 'fortify',
-			base: 'level'},
-			{name: 'cleanse',
-			base: 'level'},
-			{name: 'dispel',
-			base: 'level'}
+			{name: 'revive', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(125 + stats.rune.health + gb.s(special, /([\d\.]+) health restored/));
+			}},
+			{name: 'heal', image: 'cleric_heal', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(Math.min(h[0], 125 + gb.s(special, /([\d\.]+) and \+[\d\.]+% of Health/) 
+					+ mR.winChance / 100 * (stats.rune.health + gb.s(special, /[\d\.]+ and \+([\d\.]+)% of Health/))));
+			}},
+			{name: 'mass_heal',	tokens: 2, score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(h.map( function(p, i) {
+					return Math.min(p, Math.floor(base / [1, 2, 2, 4, 4][i]));
+				}).sum() / 2);
+			}},
+			{name: 'fortify', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'cleanse', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'dispel', score: function(fR, mR, h, splash, base, special) {
+				return gb.r100(mR.level);
+			}},
+			{name: 'swap', score: function(fR, mR, h, splash, base, special) {
+				return 100 - fR.life;
+			}}
 		]
 	};
 
@@ -361,16 +396,16 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 						var str = caap.resultsText.replace(r.name, '').replace(stats.PlayerName, ''),
 							tStr = '';
 							
-						r.points = str.regex(/\+(\d+) Battle Activity Points/);
+						r.points = str.regex(/\+([\d\.]+) Battle Activity Points/);
 						if (str.regex(/(Your target is freed from polymorph!)/i) || str.regex(/(yourself)/i)) {
 							return;
 						} else if ($u.hasContent(r.wl)) {
 							var fR = gb.getRecord(session.getItem('gbWhich','gb100'));
-							tStr = str.regex(/Defense increased by (\d+)% from Divine Favor/);
+							tStr = str.regex(/Defense increased by ([\d\.]+)% from Divine Favor/);
 							if (tStr) {
 								fR.att = (stats.attack + stats.bonus.attack + (stats.defense + stats.bonus.defense) * 0.7 * (tStr.numberOnly() / 100 + 1)).dp(0);
 							} else {
-								tStr = str.regex(/Attack increased by (\d+)% from Enrage/);
+								tStr = str.regex(/Attack increased by ([\d\.]+)% from Enrage/);
 								if (tStr) {
 									fR.att = ((stats.attack + stats.bonus.attack) * (tStr.numberOnly() / 100 + 1) + (stats.defense + stats.bonus.defense) * 0.7).dp(0);
 								}
@@ -387,6 +422,15 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				}
 			];
 			
+			gb.actions = [];
+			['your','enemy'].forEach( function(which) {
+				$j.each(gb[which], function(gbclass) {
+					gb[which][gbclass].forEach( function(action) {
+						gb.actions.addToList($u.setContent(action.image, action.name) + '.jpg');
+					});
+				});
+			});
+		
        } catch (err) {
             con.error("ERROR in gb.init: " + err.stack);
             return false;
@@ -482,10 +526,10 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				return fR;
 			}
 							
-			fR.state == 'Active';
+			fR.state = 'Active';
 			
 			if (caap.hasImage(gf.enterButton)) {
-				//con.log(2, 'Battle has enter button', config.getItem('guild_battle_enter',false));
+				fR.lastBattleTime = 0;
 				return fR;
 			}
 			
@@ -499,7 +543,6 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 			}
 
 			fR.lastBattleTime = now;
-			//con.log(2, 'Enter button cleared');
 
 			tStr = $u.setContent($j("#monsterTicker").text().trim(),'');
             fR.endTime = now + tStr.parseTimer() * 1000;
@@ -600,6 +643,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				gf = gb[fR.label], 
 				tempDiv = $j(),
 				mR = {}, // member record
+				towerType = '',
 				isMe = false,
 				wl = fR.your.health > fR.enemy.health + 20 || fR.enemy.health > fR.your.health + 20, 
 				idList = $u.setContent($j.makeArray(gate.find('div[id^="target_tag_"]').map(function() {
@@ -607,13 +651,17 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				})),$j.makeArray(gate.find('div[id^="action_panel_"][id$="_0"]').map(function() {
 					return $j(this).attr('id');
 				}))),
-				argList = $u.setContent($u.setContent(gate.text(), '').trim().innerTrim().regex(/(\d+)\. (.*?) Level: (\d+) Status: (\w+) (\d+)\/(\d+) Battle Points: (\d+)/g),[]),
-				picsText = $j.makeArray(gate.find('img').map(function(e) {
+				argList = $u.setContent($u.setContent(gate.text(), '').trim().innerTrim().regex(/(\d+)\. (.*?) Level: (\d+) Status: (\w+) ([\d\.]+)\/(\d+) Battle Points: (\d+)/g),[]),
+				pics = [],
+				picsList = [],
+				picsText = $j.makeArray(gate.find('img[src*="."], input[src*="."]').map(function(e) {
 					return $j(this).attr('src').regex(/(\w+\.\w+)$/); 
 				})).join(' ') + ' w.w class_w.gif',
+				noSwap = !picsText.hasIndexOf('wall_move_icon.jpg'),
 				n = 0,
 				args = [],
-				pics = [],
+				healths = [],
+				img = '',
 				bR = {}, // battle record
 				scoring = config.getItem(gf.scoring,''),
 				score = [],
@@ -622,18 +670,23 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				total = 0,
 				sealCheck = false,
 				fullText = '',
-				theGeneral = 'Use Current';
+				gen = 'Use Current',
+				gO = {},
+				temp = 0,
+				splash = 0,
+				base = 0;
 				
-			if (idList.length != argList.length) {
-				con.warn(fR.label + ': Unable to parse ' + which + ' tower ' + tower);
+			if (idList.length && idList.length != argList.length) {
+				con.warn(fR.label + ': Unable to parse ' + which + ' tower ' + tower + ' because FB ID list and opponents text number differ', idList, argList);
 				return false;
 			}
 				
-			argList.forEach( function(args) {
+			argList.forEach( function(args, i) {
 				mR = new gb.member().data;
 				mR.target_id = $u.hasContent(idList) ? idList.shift().regex(/(\d+)/) : 0;
 
-				pics = $u.setContent(picsText.regex(/(.*?) \w+\.\w+ class_\w+\.gif/), '').trim().split(' ');
+				pics = $u.setContent(picsText.regex(/(.*?\w+\.\w+ class_\w+\.gif.*?) \w+\.\w+ class_\w+\.gif/), '').trim().split(' ');
+				picsList.push(pics);
 				picsText = picsText.replace(pics.join(' '), '').trim();
 
 				if (!$u.hasContent(pics) || !args || args.length != 7) {
@@ -649,38 +702,85 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				mR.points = ['160', '200', '240'][['low','mid','high'].indexOf($u.setContent(pics.listMatch(/guild_bp_(\w+)\.jpg/), 'low'))];
 				mR.percent = ((mR.healthNum / mR.healthMax) * 100).dp(2);
 
-				bR = battle.getRecord(mR.target_id);
-				bR.level = mR.level;
-				
-				fR.att = fR.att || stats.bonus.api;
-				['duel', 'poly','confuse'].forEach(function(awin) {
-					if (mR.poly) {
-						mR.metrics[awin] = 100;
-					} else {
-						// If enrage or divine favor, assume has 100% bonus. Could do more detailed calc based on time passed in game and number of tokens possibly spent, but 100% bonus is a good place to start.
-						mR.metrics[awin] = battle.winChance(bR, (awin == 'confuse' ? 1.5 : awin == 'poly' ? 1.25 : 1) * fR.att, pics.hasIndexOf('mage_effect_enrage.gif') || pics.hasIndexOf('cleric_effect_divine_favor.gif'));
-					}
-				});
-				mR.winChance = mR.metrics.duel;
+				// If enrage or divine favor, assume has 100% bonus. Could do more detailed calc based on time passed in game and number of tokens possibly spent, but 125% bonus is a good place to start.
 				mR.metrics.damage = Math.atan((mR.healthMax - mR.healthNum)/1000)/Math.PI*2*100;
-				mR.metrics.level = Math.atan(mR.level/1000)/Math.PI*2*100;
 				mR.metrics.rhealth = 100 - Math.atan(Math.max(mR.healthNum - gf.minHealth, 0)/1000)/Math.PI*2*100;
 				
 				tR.players += 1;
 				tR.actives += mR.battlePoints > 0 ? 1 : 0;
 				tR.AC += (mR.battlePoints > 0 && mR.mclass == 'cleric') ? 1 : 0;
-				tR.healthNum += mR.healthNum;
+				tR.healthNum += $u.isString(mR.healthNum) ? mR.healthNum.parseFloat() : mR.healthNum;
 				tR.healthMax += mR.healthMax;
-				isMe = which == 'your' && mR.name == stats.PlayerName && mR.level == stats.level;
-				if (isMe) {
+				mR.isMe = which == 'your' && mR.name == stats.PlayerName && mR.level == stats.level;
+				if (mR.isMe) {
 					fR.me.tower = tower;
 				}
+				fR[which].members[tower + '-' + n] = mR;
+			});
 				
-				(gf.label == 'loe' ? ['mage','warrior','rogue','cleric'] : [fR.me.mclass]).forEach( function(mclass) {
-					gb[which][mclass].forEach(function(att) {
-						args = ' '.concat(scoring).match(new RegExp("\\W" + att.name + "(\\[.*?)\\]"));
-						//con.log(2,'scoring match attack', scoring, args, att.name);
-						if (!args || args.length === 0 || ($u.isBoolean(att.self) && att.self !== isMe)) {
+			tR.damage = tR.healthMax - tR.healthNum;
+			tR.life = (tR.healthNum/tR.healthMax * 100).dp(1);
+
+			(gf.label == 'loe' ? ['mage','warrior','rogue','cleric'] : [fR.me.mclass]).forEach( function(mclass) { 
+				gb[which][mclass].forEach(function(att) {
+					// Figure out general and calculate splashes
+					fullText = scoring.regex(new RegExp("\\b" + att.name + "(\\[.*?)\\]"));
+					img = att.image || att.name;
+					gen = $u.setContent($u.setContent(fullText, '').regex(/@([^,]+)/), general.loadout);
+					gO = general.getRecord(gen);
+					gen = gO.powers.hasIndexOf(img) ? gen : general.getRecordByField('powers', new RegExp(img)).name;
+					if (!fullText || gen == '' || !picsList.length || picsList[0].hasIndexOf('guild_power_locked.jpg') 
+						|| (att.name == 'swap' && noSwap)) {
+						return;
+					}
+										
+					// Max splash damage
+					if (mclass == 'mage' && which == 'enemy' && !splash) {
+						splash = (Math.min(stats.rune.damage, 500) * 0.1 + 10) * 0.1 * (gb.s(gO.special, /(\d+)% damage to Mage/) + 1);
+						// Total splash damage for tower
+						splash = Object.keys(fR[which].members).map( function(k) {
+							return k.match(tower + '-') ? Math.max(splash, fR[which].members[k].healthNum) : 0;
+						}).sum();
+					} else if (mclass == 'cleric') {
+						if (which == 'enemy' && ['attack', 'divine_favor'].hasIndexOf(img)) {
+							if ($u.isDefined(fR.healGen[gen])) {
+								splash = fR.healGen[gen];
+							} else {
+								fR.healGen[gen] = 0;
+							}
+						} else if (which == 'your' && tower == fR.me.tower && !splash) {
+							Object.keys(fR.healGen).forEach( function(g) {
+								splash = gb.s(gO.special, /(\d+)% heal to Cleric/);
+								splash = (Math.min(stats.rune.health, 500) * 0.1 + 10 + Math.floor(splash / 2)) * (splash / 100 + 1);
+								// Total splash damage for tower
+								fR.healGen[g] = Object.keys(fR[which].members).map( function(k) {
+									return k.match(tower + '-') 
+										? Math.max(splash, fR[which].members[k].healthMax - fR[which].members[k].healthNum) : 0;
+								}).sum();
+							});
+						}
+					}
+					
+					picsList.forEach( function(pics, i) {
+						mR = fR[which].members[tower + '-' + (i + 1)];
+
+						bR = battle.getRecord(mR.target_id);
+						bR.level = mR.level;
+						
+						fR.att = fR.att || stats.bonus.api;
+						mR.winChance = mR.poly ? 100 : battle.winChance(bR, (att.name == 'confuse' ? 1.5 : att.name == 'poly' ? 1.25 : 1) 
+							* fR.att, pics.hasIndexOf('mage_effect_enrage.gif') || pics.hasIndexOf('cleric_effect_divine_favor.gif') ? 1.25 : 0);
+						
+						base = 110 * $u.setContent(att.tokens, 1) + gb.s(gO.special, /([\d\.]+) Damage, \+[\d\.]+% Damage/) 
+							+ pics.hasIndexOf('rogue_effect_poison.gif') * 35 - pics.hasIndexOf('warrior_ability_sentinel.gif') * 200
+							+ stats.rune.damage * (1 + gb.s(gO.special, /[\d\.]+ Damage, \+([\d\.]+)% Damage/)
+							+ pics.hasIndexOf('rogue_effect_poison.gif') * 0.1 - pics.hasIndexOf('warrior_ability_sentinel.gif') * 0.15);
+
+						if (!(stats.guild.powers).regex(img)) {
+							return;
+						}
+						towerType = $u.hasContent(towerTypes) && towerTypes.length ? towerTypes[tower - 1].toLowerCase() : false;
+						if ($u.isBoolean(att.self) && att.self !== mR.isMe) {
 							return;
 						}
 						if (!fR[which].attacks) {
@@ -692,7 +792,6 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 						score = [1, 0];
 						sealCheck = false;
 						sealScore = [0, 0];
-						fullText = args[1];
 						
 						$u.setContent(fullText.match(/(!?\w+:\D?[^,]+)/g),[]).forEach( function(text) {
 							var key = text.replace(/:.*/,'').replace('!','').toLowerCase(),
@@ -719,7 +818,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 								case 'elemental' : 	
 								case 'null' : 	
 								case 'gate' : 	
-								case 'sewer' : 		tf = $u.hasContent(towerTypes) && towerTypes.length ? towerTypes[tower - 1].toLowerCase() === key : false;					break;
+								case 'sewer' : 		tf = towerType == key;												break;
 								case 'poly' : 		tf = pics.hasIndexOf('polymorph_effect.gif'); 						break;
 								case 'poison' : 	tf = pics.hasIndexOf('rogue_effect_poison.gif'); 					break;
 								case 'confuse' : 	tf = pics.hasIndexOf('mage_effect_confuse.gif'); 					break;
@@ -741,7 +840,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 								case 'healed' : 	tf = mR.healthMax - mR.healthNum < 300; 							break;
 								case '100v100' : 	
 								case 'classic' : 	
-								case '10v10' : 		tf = gf.label == key;		 										break;
+								case '10v10' : 		tf = gf.name.toLowerCase() == key;		 							break;
 								case 'easy' : 		tf = fR.easy; 														break;
 								case 'easyc' : 		tf = fR.easy && mR.mclass == 'cleric'; 								break;
 								case mR.target_id : tf = true; 															break;
@@ -763,7 +862,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 									break;
 								default : 			
 									if (!/\d+/.test(key)) {
-										con.log(1, 'Unknown guild battle modifier: ' + key, fullText, att, args);
+										con.log(1, 'Unknown guild battle modifier: ' + key, fullText, att);
 									}
 							}
 
@@ -783,36 +882,35 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 
 						mR.scores[att.name] = {};
 						tempScore = [score[0], score[1]];
+						healths = [0, 1, -1, 2, -2].map( function(h){
+							temp = fR[which].members[tower + '-' + (i + 1 + h)];
+							return $u.hasContent(temp) ? temp.healthNum : 0;
+						});
 						['normal','seal'].forEach(function(seal) {
 							score = seal == sealCheck ? [tempScore[0] + sealScore[0], tempScore[1] + sealScore[1]] : [tempScore[0], tempScore[1]];
-							total = score[0] * mR.metrics[att.base] + score[1];
-							total = (gf.label == 'loe' || towerTypes[tower - 1] != 'Keep' || which == 'your' || sealedTowers == 3)
-								&& mR.healthNum >= (which == 'your' ? gf.minHealth : 1) ? total.dp(2) : 0;
+							total = score[0] * att.score(fR, mR, healths, splash, base, gO.special) + score[1];
+							total = mR.healthNum >= (which == 'your' ? gf.minHealth : 1) ? total.dp(2) : 0;
 							mR.scores[att.name][seal] = total;
-							theGeneral = fullText.match(new RegExp("@[^,]+"));
-							theGeneral = theGeneral && theGeneral.length > 0 ? theGeneral[0] : '@Use Current';
-							tR[seal].unstunned = gb.target(tR[seal].unstunned, total, mR, att.image || att.name, theGeneral, which, tower, $u.setContent(att.tokens, 1));
+							tR[seal].unstunned = gb.target(tR[seal].unstunned, total, mR, img, gen, which, tower, $u.setContent(att.tokens, 1));
 							if (which == 'enemy' && att.name.regex(/duel/)) {
-								tR[seal].stunned = gb.target(tR[seal].stunned, total, mR, att.image || att.name, theGeneral, which, tower, $u.setContent(att.tokens, 1));
+								tR[seal].stunned = gb.target(tR[seal].stunned, total, mR, img, gen, which, tower, $u.setContent(att.tokens, 1));
 							}
 						});
 
+						fR[which].members[tower + '-' + (i + 1)] = mR;
 					});
 				});
-				fR[which].members[tower + '-' + n] = mR;
 			});
 
 
 			Object.keys(fR[which].members).forEach( function(k) {
 				n = $u.setContent(k.regex(new RegExp(tower + '-(\\d+)'), 0));
-				if (n > idList.length + 1) {
+				if (n > argList.length + 1) {
 					delete fR[which].members[tower + '-' + n];
 				}
 			});
 
 			
-			tR.damage = tR.healthMax - tR.healthNum;
-			tR.life = (tR.healthNum/tR.healthMax * 100).dp(1);
 			fR.firstScanDone = true;
 			fR[which].towers[tower] = tR;
 
@@ -823,7 +921,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				towerList.forEach(function(fTower) {
 					tR = fR[fwhich].towers[fTower];
 					if ($u.isObject(tR)) {
-						if ($u.isNumber(tR.damage) && tR.damage > maxDamage + 1000 && tR.healthNum > 0) {
+						if ($u.isNumber(tR.damage) && tR.damage > maxDamage + 5000 && tR.healthNum > 0) {
 							maxDamage = tR.damage;
 							maxTower = fTower;
 						}
@@ -840,6 +938,10 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
         }
     };
 	
+	gb.r100 = function(n) {
+		return Math.atan(n/1000)/Math.PI*2*100;
+	};
+	
 	gb.worker = function () {
         try {
 			var fRecord = gb.getRecord('gb100'),
@@ -847,10 +949,10 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				tRecord = gb.getRecord('gb10'),
 				configSet = false;
 				
-			if (schedule.since(fRecord.startTime, 1 * 60) && !schedule.since(fRecord.startTime, 4* 60)) {
+			if (schedule.since(fRecord.startTime, -15 * 60) && !schedule.since(fRecord.startTime, -5 * 60)) {
 				stats.priorityGeneral = config.getItem('100v100_ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('100v100_ClassGeneral','Use Current');
 			}
-			if (stats.priorityGeneral == 'Use Current' && schedule.since(tRecord.startTime, -8 * 60) && !schedule.since(tRecord.startTime, -0 * 60)) {
+			if (stats.priorityGeneral == 'Use Current' && schedule.since(tRecord.startTime, -15 * 60) && !schedule.since(tRecord.startTime, -5 * 60)) {
 				stats.priorityGeneral = config.getItem('10v10_ClassGeneral','Use Current') == 'Use Current' ? 'Use Current' : config.getItem('10v10_ClassGeneral','Use Current');
 			}
 			if (stats.priorityGeneral == 'Use Current' && gRecord.state == 'Auto-match') {
@@ -904,7 +1006,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				bR = {},
 				mess = gf.label + '_mess',
 				towers = gf.name == '10v10' ? ['1'] : ['1','2','3','4'],
-				t = { 'score' : 0, 'tokens' : 1 },
+				t = { score: 0, tokens: 1 },
 				stateMsg = schedule.since(fR.collectedTime, gf.waitHours * 60 * 60) ? 'Uncollected' : 'Collected';
 			
 			tObj = fR.t;
@@ -1050,8 +1152,8 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 					con.log(2,  stateMsg + t.attack + ' on ' + t.team + ' T' + t.tower + ' ' + t.name, t);
 					result = caap.navigate2(t.general + ',' + gb.makePath(gf, t.team, t.tower) + ',clickjq:.action_panel_' + t.id + ' input[src*="' + t.attack + '.jpg"]');
 					if (result == 'fail') {
-						con.warn(stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.getCurrentGeneral() + ' has ' + t.attack + ', reloading page', general.getCurrentGeneral(), general.getCurrentLoadout());
-						caap.setDivContent(mess, stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.getCurrentGeneral() + ' has ' + t.attack);
+						con.warn(stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack + ', reloading page', general.current, general.loadout);
+						caap.setDivContent(mess, stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack);
 						gb.setRecord(fR);
 						return caap.navigate2(gb.makePath(gf, t.team == 'enemy' ? 'your' : 'enemy', t.tower));
 					} else if (result == 'done') {
@@ -1103,7 +1205,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				rPage[entry] = value;
 			}
 
-			fR.paths.push(rPage);
+			fR.paths.unshift(rPage);
 			gb.setRecord(fR);
 			
 			return false;
@@ -1185,7 +1287,7 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				t.score = total;
 				t.attack = attack;
 				t.team = team;
-				t.general = general;
+				t.general = '@' + general;
 				t.id = mR.target_id;
 				t.name = mR.name;
 				t.level = mR.level;

--- a/Chrome/unpacked/js/worker_general.js
+++ b/Chrome/unpacked/js/worker_general.js
@@ -14,40 +14,40 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 (function () {
     "use strict";
 
-	worker.add('general');
+	worker.add({ name: 'general', recordIndex: 'name'});
 
-	worker.addRecordFunctions('general');
-	general.recordIndex = 'name';
     general.record = function () {
         this.data = {
-            'name': '',
-            'img': '',
-            'lvl': 0,
-            'lvlmax': 0,
-            'pct': 0,
-            'last': 0,
-            'special': '',
-            'atk': 0,
-            'def': 0,
-            'api': 0,
-            'dpi': 0,
-            'mpi': 0,
-            'eatk': 0,
-            'edef': 0,
-            'eapi': 0,
-            'edpi': 0,
-            'empi': 0,
-            'energy': 0,
-            'stamina': 0,
-            'attackItemBonus': 0,
-            'defenseItemBonus': 0,
-            'health': 0,
-            'item': 0,
-            'itype': 0,
-            'coolDown': false,
-            'charge': 0,
-            'general': 'Use Current',
-            'value':0
+            name : '',
+            img : '',
+            lvl : 0,
+            lvlmax : 0,
+            pct : 0,
+            last : 0,
+            special : '',
+            atk : 0,
+            def : 0,
+            api : 0,
+            dpi : 0,
+            mpi : 0,
+            eatk : 0,
+            edef : 0,
+            eapi : 0,
+            edpi : 0,
+            empi : 0,
+            energy : 0,
+            stamina : 0,
+            attackItemBonus : 0,
+            defenseItemBonus : 0,
+            health : 0,
+            item : 0,
+            itype : 0,
+            coolDown : false,
+            charge : 0,
+            general : 'Use Current',
+            value :0,
+			loadoutReview : 0,
+			powers : ''
         };
     };
 
@@ -84,271 +84,80 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
         'GB Idle',
         'Level Up'];
 
-    general.filters = {
-        'Buy' : [
-            'Darius',
-            'Lucius',
-            'Garlan',
-            'Penelope'],
-        'Income' : [
-            'Scarlett',
-            'Mercedes',
-            'Cid'],
-        'Banking' : [
-            'Aeris'],
-        'Collect' : [
-            'Angelica',
-            'Morrigan',
-            'Valiant'],
-        'SubQuest' : [
-            'Under Level',
-            'Sano',
-            'Titania']
-    };
-
-    general.parseTime = function (timeString) {
-        if (timeString == '') return null;
-
-        var time = timeString.match(/(\d+)(:(\d\d))?\s*(p?)/i);
-        if (time == null) return null;
-
-        var hours = parseInt(time[1],10);
-        if (hours == 12 && !time[4]) {
-              hours = 0;
-        }
-        else {
-            hours += (hours < 12 && time[4])? 12 : 0;
-        }
-        var d = new Date();
-        d.setHours(hours);
-        d.setMinutes(parseInt(time[3],10) || 0);
-        d.setSeconds(0, 0);
-        return d;
-    };
-
-    // Parse the menu item too see if a loadout override should be equipped.  If time is during a general override time,
-    // the according general will be equipped, and a value of True will be returned continually to the main loop, so no
-    // other action will be taken until the time is up.
-    // Returns false if not timed set, "change" if a timed loadout was changed, and "set" if done setting a timed loadout
-    general.timedLoadout = function () {
-        try {
-            var timedLoadoutsList = config.getList('timed_loadouts', ''),
-                begin = 0,
-                end = 0,
-                match = false,
-                change = false,
-                returnValue = 'change',
-                targetGeneral = '',
-                timeStrings = '',
-                now = new Date();
-            // Priority generals, such as Guild Battle class generals, outrank timed generals.
-            if (stats.priorityGeneral != 'Use Current') {
-                timeStrings = now.toLocaleTimeString().replace(/:\d+ /,' ') + '@' + stats.priorityGeneral;
-                timedLoadoutsList.unshift(timeStrings);
-                con.log(2,'Priority gen set', timeStrings, timedLoadoutsList);
-            }
-            con.log(5, 'timedLoadoutsList', timedLoadoutsList);
-            // Next we step through the users list getting the name and conditions
-            for (var p = 0, len = timedLoadoutsList.length; p < len; p++) {
-                if (!timedLoadoutsList[p].toString().trim()) {
-                    continue;
-                }
-                timeStrings = timedLoadoutsList[p].toString().split('-');
-                con.log(4,'timeStrings',timeStrings);
-                if (timeStrings.length === 1) {
-                    begin = general.parseTime(timeStrings[0]) - 2 * 60 * 1000;
-                    end = begin + 4 * 60 * 1000;
-                } else {
-                    begin = general.parseTime(timeStrings[0]);
-                    end = general.parseTime(timeStrings[1]);
-                    end = end > begin ? end : end.setHours(end.getHours() +  24);
-                    // Need to add a check here in case going over midnight hour
-                }
-                con.log(4,'begin ' + $u.makeTime(begin, caap.timeStr(true)) + ' end ' + $u.makeTime(end, caap.timeStr(true)) + ' time ' + $u.makeTime(now, caap.timeStr(true)), begin, end, now);
-
-                if (begin < now && now < end) {
-                    match = true;
-                    con.log(4, 'valid time of ',timeStrings);
-                }
-                // Now we check the other elements to look for a general name to load, prefixed with '@'
-                if (match && timedLoadoutsList[p].toString().split('@').length > 1) {
-                    targetGeneral = timedLoadoutsList[p].toString().split('@')[1].trim();
-                    con.log(2, 'Timed general set:', targetGeneral);
-                    return targetGeneral;
-                }
-            }
-            return false;
-        } catch (err) {
-            con.error("ERROR in general.timedLoadout: " + err.stack);
-            return false;
-        }
-    };
-
-	general.resetCharge = function() {
-        try {
-			var genObj = general.getRecord(general.getCurrentGeneral());
-			if (genObj.coolDown > 0 && schedule.since(genObj.charge, 0)) {
-				genObj.charge = Date.now() + genObj.coolDown * 3600000;
-				con.log(2, 'Reset general charge for ' + genObj.name + ' to be ready ' + $u.makeTime(genObj.charge, caap.timeStr(true)), genObj);
-				general.setRecord(genObj);
-			}
-        } catch (err) {
-            con.error("ERROR in general.resetCharge: " + err.stack);
-            return false;
-        }
-    };
-	
-    // Look up a stat for a general.
-    general.getLevelUpNames = function () {
-        try {
-            var names = [],
-				generalName = '';
-
-            general.records.forEach( function(r) {
-				generalName = general.getLoadoutGeneral(r.name);
-			    if (generalName != 'Use Current' && general.getRecordVal(generalName, 'pct', 0) < 100) {
-                    names.push(r.name);
-                }
-            });
-
-            return names;
-        } catch (err) {
-            con.error("ERROR in general.getLevelUpNames: " + err.stack);
-            return false;
-        }
-    };
-
-    general.getCoolDownNames = function () {
-        try {
-            var names = [];
-
-			general.records.forEach( function(r) {
-                if (r.coolDown) {
-                    names.push(r.name);
-                }
-            });
-
-            return names.sort();
-        } catch (err) {
-            con.error("ERROR in general.getCoolDownNames: " + err.stack);
-            return false;
-        }
-    };
-
-    general.isLoadout = function (name) {
-        try {
-            if (!$u.isString(name) || name.indexOf('Loadout ') < 0) {
-                return false;
-            }
-            return name.replace('Loadout ','');
-        } catch (err) {
-            con.error("ERROR in general.isLoadout: " + err.stack);
-            return false;
-        }
-    }
-
-    general.BuildLists = function () {
-        try {
-            var it = 0,
-                len = 0,
-                fullList = [],
-                generalList = [],
-				defaultLoadout = config.getItem('Default Loadout', 'Use Current'),
-                usedGen = '',
-				uGR = {},
-				generalNames = [],
-                crossList = function (checkItem) {
-                    return generalList.hasIndexOf(checkItem) >= 0;
-                };
-
-            con.log(2, 'Building Generals Lists');
-			
-			['energy', 'stamina', 'health'].forEach(function(stat) {
-				stats[stat].min = 0;
+    general.init = function() {
+		try {
+			var result = ['gb100', 'gb10', 'gbClassic'].some( function(label) {
+				return config.getItem(label + 'whenTokens') != 'Never';
 			});
 			
-			generalNames = general.records.flatten('name');
-
-			generalNames.forEach( function(n) {
-			    if (!general.isLoadout(n)) {
-                    general.GeneralsList.addToList(n);
-                } else {
-                    general.LoadoutsList.addToList(n);
-                }
-            });
-            general.GeneralsList = general.GeneralsList.sort();
-            fullList = general.LoadoutsList.concat(general.GeneralsList);
-            generalList = ['Under Level'].concat(fullList);
-
-            general.menuList.forEach(function(item) {
-                usedGen = config.getItem(item + 'General', 'Use Current');
-                if (['Use Current', 'Under Level', ''].indexOf(usedGen) == -1 && general.usedGenerals.indexOf(usedGen) == -1) {
-                    general.usedGenerals.addToList(usedGen);
-					uGR = general.getRecord(usedGen);
-					['energy', 'stamina', 'health'].forEach(function(stat) {
-						if (general.isLoadout(usedGen)) {
-							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat], 0));
-						} else if (defaultLoadout == 'Use Current') {
-							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat], 0));
-						} else {
-							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat] + general.getRecord(defaultLoadout)[stat], 0));
-						}
-						//con.log(2, 'Min loadout/general en/sta adjustment calc', uGR, stats[stat].min, stats[stat]);
-					});
-                }
-                general.lists[item] = ($u.isArray(general.filters[item]) && config.getItem("filterGeneral", true)) ? general.filters[item].filter(crossList) : generalList;
-            });
-
-            general.coolDownList = [''].concat(general.getCoolDownNames());
-
-            con.log(2, 'Built lists',general.LoadoutsList, general.lists, general.usedGenerals, stats);
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in general.BuildLists: " + err.stack);
-            return false;
-        }
-    };
-
-    general.quickSwitch = false;
-    general.clickedLoadout = false;
-
-    general.assignStats = function (generalRecord, eatk, edef) {
+			if (!result) {
+				return;
+			}
+			
+			var loadoutVals = general.records.flatten('value').filter( function(v) {
+				return v;
+			});
+			
+			loadoutVals.forEach( function(v) {
+				worker.addPageCheck({page : 'ajax:player_loadouts.php?loadout=' + v, hours : 5});
+			});
+			
+			return true;
+		} catch (err) {
+			con.error("ERROR in general.init: " + err.stack);
+			return false;
+		}
+	};
+	
+    general.checkResults = function (page) {
         try {
-            generalRecord.eatk = eatk;
-            generalRecord.edef = edef;
-            generalRecord.eapi = (generalRecord.eatk + (generalRecord.edef * 0.7)).dp(2);
-            generalRecord.edpi = (generalRecord.edef + (generalRecord.eatk * 0.7)).dp(2);
-            generalRecord.empi = ((generalRecord.eapi + generalRecord.edpi) / 2).dp(2);
-			['energy', 'stamina', 'health'].forEach(function(stat) {
-				if (stats[stat].norm && stats[stat].max) {
-					generalRecord[stat] = stats[stat].max - stats[stat].norm;
-					//con.log(2, 'Updated ' + stat + ' adjustement for ' + generalRecord.name + ' to ' + generalRecord[stat], generalRecord, stats[stat]);
-					if (general.usedGenerals.indexOf(generalRecord.name) > 0) {
-						stats[stat].min = Math.min(stats[stat].min, generalRecord[stat]);
-					}
+			// Shrink the general box
+            var generalBox = $j('div[style*="hot_general_container.gif"]');
+
+            if (generalBox[0]) {
+                generalBox[0].style.zIndex = 1;
+                generalBox.mouseover(function () {
+                    this.style.zIndex = 100;
+                });
+
+                generalBox.mouseout(function () {
+                    this.style.zIndex = 1;
+                });
+            }
+
+			// Get Loadouts
+            var name = '',
+				loadoutsDiv = $j('#hot_swap_loadouts_div select[name="choose_loadout"] option'),
+                loadoutsList = loadoutsDiv.map(function() {
+                    return this.text;
+                }).get();
+
+            // Record current loadouts
+            loadoutsList.forEach( function(l, i) {
+				name = 'Loadout ' + l;
+				if (general.records.length < i + 1) {
+					general.records.push(new general.record().data);
+				}
+				if (name !== general.records[i].name) {
+					general.records[i] == new general.record().data;
+					con.log(1, "Adding new 'Loadout'", name, general.records);
+					general.records[i].name = name;
+					general.records[i].value = i + 1;
+					general.doSave = true;
 				}
 			});
-            generalRecord.last = Date.now();
-            caap.updateDashboard(true);
-            general.setRecord(generalRecord);
-            //con.log(2, "Got general stats for " + generalRecord.name, generalRecord);
-            return true;
-        } catch (err) {
-            con.error("ERROR in general.assignStats: " + err.stack);
-            return false;
-        }
-    }
-
-    // Called after a page load, this records the specific information for each general that cannot be seen if the
-    // general isn't equipped, such as item bonuses to general or max sta/energy and the max stamina/energy/health.
-    general.getEquippedStats = function () {
-        try {
+			stats.records.total = general.records.length;
+			
+			// Add code to check for a general level up pop-up here? -- Artifice
+			
+			//Get current general and loadout
+			general.worker('force', generalBox, loadoutsDiv);
+			
+			// Called after a page load, this records the specific information for each general that cannot be seen if the
+			// general isn't equipped, such as item bonuses to general or max sta/energy and the max stamina/energy/health.
             general.quickSwitch = false;
-            var generalName = general.getCurrentGeneral(),
-                loadoutName = general.getCurrentLoadout(),
-                loadoutRecord = general.getRecord(loadoutName),
-                generalRecord = general.getRecord(generalName),
+            var loadoutRecord = general.getRecord(general.loadout),
+                generalRecord = general.getRecord(general.current),
                 defaultLoadout = config.getItem("DefaultLoadout", 'Use Current'),
                 generalDiv = $j(),
                 tempObj = $j(),
@@ -364,16 +173,16 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 					con.log(2, general.records[general.clickedLoadout].name + " is not configured.");
 				} else if (general.clickedLoadout == loadoutRecord.value - 1) {
 					general.records[general.clickedLoadout].last = Date.now();
-					if (loadoutName == general.records[general.clickedLoadout].name && general.records[general.clickedLoadout].general !== generalName) {
-						con.log(2,"Updated general for " + general.records[general.clickedLoadout].name + " is " + generalName, general.records);
-						general.records[general.clickedLoadout].general = generalName;
+					if (general.loadout == general.records[general.clickedLoadout].name && general.records[general.clickedLoadout].general !== general.current) {
+						con.log(2,"Updated general for " + general.records[general.clickedLoadout].name + " is " + general.current, general.records);
+						general.records[general.clickedLoadout].general = general.current;
 					}
 				}
 			}
 			general.clickedLoadout = false;
 
-            if (generalName === 'Use Current' || !generalRecord) {
-                con.warn("Get Equipped Stats: Unable to find 'General' record", generalName);
+            if (general.current === 'Use Current' || !generalRecord) {
+                con.warn("Get Equipped Stats: Unable to find 'General' record", general.current);
                 return false;
             }
 
@@ -394,10 +203,10 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
                 }
 
                 if (success) {
-                    if (loadoutName === defaultLoadout || defaultLoadout == 'Use Current') {
+                    if (general.loadout === defaultLoadout || defaultLoadout == 'Use Current') {
                         general.assignStats(generalRecord, eatk, edef);
                     }
-                    if (loadoutRecord.general === generalName) {
+                    if (loadoutRecord.general === general.current) {
                         general.assignStats(loadoutRecord, eatk, edef);
                     }
 
@@ -408,86 +217,15 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
                 con.warn("Unable to get equipped 'General' div");
             }
 
-            return generalRecord;
-        } catch (err) {
-            con.error("ERROR in general.getEquippedStats: " + err.stack);
-            return false;
-        }
-    };
-
-    // Called every page load.  Records all loadouts
-    general.getLoadouts = function() {
-        try {
-            var name = '',
-                loadoutsList = $j('#hot_swap_loadouts_div select[name="choose_loadout"] option').map(function() {
-                    return this.text;
-                }).get();
-
-            // Record current loadouts
-            if ($u.hasContent(loadoutsList)) {
-                for (var it = 0, len = loadoutsList.length; it < len; it += 1) {
-                    name = 'Loadout ' + loadoutsList[it];
-                    if (general.records.length < it + 1) {
-                        general.records.push(new general.record().data);
-                    }
-                    if (name !== general.records[it].name) {
-                        general.records[it] == new general.record().data;
-                        con.log(1, "Adding new 'Loadout'", name, general.records);
-                        general.records[it].name = name;
-                        general.records[it].value = it + 1;
-                        general.doSave = true;
-                    }
-                }
-                stats.records.total = general.records.length;
-                if (general.doSave) {
-                    caap.updateDashboard(true);
-                    general.UpdateDropDowns();
-                }
-				
-				// Add code to check for a general level up pop-up here?
-
-                con.log(5, "loadoutslist done", general.records);
-                return true;
-            } else if (stats.level > 100) {
-                con.warn("Couldn't get 'loadouts'.");
+            if ($u.hasContent(general.List) && general.List.length <= 2) {
+                schedule.setItem("generals", 0);
+                schedule.setItem("allGenerals", 0);
+                caap.checkGenerals();
             }
-            return false;
-        } catch (err) {
-            con.error("ERROR in general.getLoadouts: " + err.stack);
-            return false;
-        }
-    };
-
-    general.Shrink = function () {
-       try {
-            var generalBox = $j('div[style*="hot_general_container.gif"]');
-
-            if (generalBox[0]) {
-                generalBox[0].style.zIndex = 1;
-                generalBox.mouseover(function () {
-                    this.style.zIndex = 100;
-                });
-
-                generalBox.mouseout(function () {
-                    this.style.zIndex = 1;
-                });
-            }
-
-            generalBox = null;
-        } catch (err) {
-            con.error("ERROR in general.shrink: " + err.stack);
-        }
-    };
-
-    // If on the Loadouts page after clicking loadout, then the player hasn't configured that loadout.
-    general.checkResults_loadouts = function () {
-        // May add something here to reset a bad loadout to 'Use Current'
-    };
-
-    // Called when visiting the generals page, this records the basic information of all generals
-    general.checkResults = function (page) {
-        try {
+			
 			switch (page) {
+
+			// On generals page, this records the basic information of all generals
 			case 'generals' :
 				var generalsDiv = $j("#app_body div.generalSmallContainer2"),
 					update = false;
@@ -623,20 +361,318 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 							general.UpdateDropDowns();
 						}
 					}
-
-					con.log(5, "general.checkResults_onGenerals", general.records);
 				}
 
 				generalsDiv = null;
-				return true;
+				break;
+			case 'player_loadouts' :
+				var lNum = $j('#loadout_selection_section select[name="choose_loadout"] option:selected').attr('value');
+				
+				if (!lNum) {
+					return false;
+				}
+				
+				session.setItem('clickUrl', 'player_loadouts.php?loadout=' + lNum);
+				chores.checkResults(); // A bit kludgey to call here, but it works
+				
+				var gO = general.getRecordByField('value', lNum.numberOnly());
+				gO.powers = $j.makeArray($j('#loadout_powers').find('img').map(function(e) {
+					return $j(this).attr('src').regex(/(\w+\.\w+)$/); 
+				})).join(' ') + ' attack swap';
+				general.setRecord(gO);
+				
+				stats.guild.powers = [];
+				general.records.flatten('powers').forEach( function(p) {
+					p.split(' ').forEach( function(e) {
+						stats.guild.powers = stats.guild.powers.addToList(e);
+					});
+				});
+				stats.guild.powers = stats.guild.powers.join(' ');
+				con.log(2, 'GB powers available: ' + stats.guild.powers);
+
+				break;
 			default :
 				break;
 			}
         } catch (err) {
-            con.error("ERROR in general.checkResults_onGenerals: " + err.stack);
+            con.error("ERROR in general.checkResults: " + err.stack);
             return false;
         }
     };
+
+	worker.addAction({worker : 'general', priority : 100000, description : 'Checking current general'});
+	general.worker = function(newpage, generalBox, loadoutsDiv) {
+		try {
+			if (!newpage && !general.quickSwitch) {
+				return false;
+			}
+			general.quickSwitch = false;
+			generalBox = $u.setContent(generalBox, $j('div[style*="hot_general_container.gif"]'));
+			loadoutsDiv = $u.setContent(loadoutsDiv, $j('#hot_swap_loadouts_div select[name="choose_loadout"] option'));
+			
+			// Get the current general
+            var generalName = $j('div:first > div:nth-child(2), #equippedGeneralContainer div.general_name_div3', generalBox).text().trim();
+
+            if (!generalName) {
+                con.warn("Couldn't get current 'General'. Using 'Use Current'");
+                general.current = 'Use Current';
+            } else {
+				general.current = generalName;
+			}
+
+			// Get the current loadout
+            var loadoutName = loadoutsDiv.filter(':selected').text().trim();
+
+            if (!loadoutName) {
+				if (stats.level >= 101) {
+					con.warn("Couldn't get current 'loadout'. Using 'Use Current'");
+				}
+                general.loadout = 'Use Current';
+            }
+
+            general.loadout = "Loadout " + loadoutName;
+			return false;
+        } catch (err) {
+            con.error("ERROR in general.worker: " + err.stack);
+            return false;
+        }
+    };
+
+    general.filters = {
+        Buy : [
+            'Darius',
+            'Lucius',
+            'Garlan',
+            'Penelope'],
+        Income : [
+            'Scarlett',
+            'Mercedes',
+            'Cid'],
+        Banking : [
+            'Aeris'],
+        Collect : [
+            'Angelica',
+            'Morrigan',
+            'Valiant'],
+        SubQuest : [
+            'Under Level',
+            'Sano',
+            'Titania']
+    };
+
+    general.parseTime = function (timeString) {
+        if (timeString == '') return null;
+
+        var time = timeString.match(/(\d+)(:(\d\d))?\s*(p?)/i);
+        if (time == null) return null;
+
+        var hours = parseInt(time[1],10);
+        if (hours == 12 && !time[4]) {
+              hours = 0;
+        }
+        else {
+            hours += (hours < 12 && time[4])? 12 : 0;
+        }
+        var d = new Date();
+        d.setHours(hours);
+        d.setMinutes(parseInt(time[3],10) || 0);
+        d.setSeconds(0, 0);
+        return d;
+    };
+
+    // Parse the menu item too see if a loadout override should be equipped.  If time is during a general override time,
+    // the according general will be equipped, and a value of True will be returned continually to the main loop, so no
+    // other action will be taken until the time is up.
+    // Returns false if not timed set, "change" if a timed loadout was changed, and "set" if done setting a timed loadout
+    general.timedLoadout = function () {
+        try {
+            var timedLoadoutsList = config.getList('timed_loadouts', ''),
+                begin = 0,
+                end = 0,
+                match = false,
+                change = false,
+                returnValue = 'change',
+                targetGeneral = '',
+                timeStrings = '',
+                now = new Date();
+            // Priority generals, such as Guild Battle class generals, outrank timed generals.
+            if (stats.priorityGeneral != 'Use Current') {
+                timeStrings = now.toLocaleTimeString().replace(/:\d+ /,' ') + '@' + stats.priorityGeneral;
+                timedLoadoutsList.unshift(timeStrings);
+                con.log(2,'Priority gen set', timeStrings, timedLoadoutsList);
+            }
+            con.log(5, 'timedLoadoutsList', timedLoadoutsList);
+            // Next we step through the users list getting the name and conditions
+            for (var p = 0, len = timedLoadoutsList.length; p < len; p++) {
+                if (!timedLoadoutsList[p].toString().trim()) {
+                    continue;
+                }
+                timeStrings = timedLoadoutsList[p].toString().split('-');
+                con.log(4,'timeStrings',timeStrings);
+                if (timeStrings.length === 1) {
+                    begin = general.parseTime(timeStrings[0]) - 2 * 60 * 1000;
+                    end = begin + 4 * 60 * 1000;
+                } else {
+                    begin = general.parseTime(timeStrings[0]);
+                    end = general.parseTime(timeStrings[1]);
+                    end = end > begin ? end : end.setHours(end.getHours() +  24);
+                    // Need to add a check here in case going over midnight hour
+                }
+                con.log(4,'begin ' + $u.makeTime(begin, caap.timeStr(true)) + ' end ' + $u.makeTime(end, caap.timeStr(true)) + ' time ' + $u.makeTime(now, caap.timeStr(true)), begin, end, now);
+
+                if (begin < now && now < end) {
+                    match = true;
+                    con.log(4, 'valid time of ',timeStrings);
+                }
+                // Now we check the other elements to look for a general name to load, prefixed with '@'
+                if (match && timedLoadoutsList[p].toString().split('@').length > 1) {
+                    targetGeneral = timedLoadoutsList[p].toString().split('@')[1].trim();
+                    con.log(2, 'Timed general set:', targetGeneral);
+                    return targetGeneral;
+                }
+            }
+            return false;
+        } catch (err) {
+            con.error("ERROR in general.timedLoadout: " + err.stack);
+            return false;
+        }
+    };
+
+	general.resetCharge = function() {
+        try {
+			var genObj = general.getRecord(general.current);
+			if (genObj.coolDown > 0 && schedule.since(genObj.charge, 0)) {
+				genObj.charge = Date.now() + genObj.coolDown * 3600000;
+				con.log(2, 'Reset general charge for ' + genObj.name + ' to be ready ' + $u.makeTime(genObj.charge, caap.timeStr(true)), genObj);
+				general.setRecord(genObj);
+			}
+        } catch (err) {
+            con.error("ERROR in general.resetCharge: " + err.stack);
+            return false;
+        }
+    };
+	
+    general.getLevelUpNames = function () {
+        try {
+            var names = [],
+				generalName = '';
+
+            general.records.forEach( function(r) {
+				generalName = general.getLoadoutGeneral(r.name);
+			    if (generalName != 'Use Current' && general.getRecordVal(generalName, 'pct', 0) < 100) {
+                    names.push(r.name);
+                }
+            });
+
+            return names;
+        } catch (err) {
+            con.error("ERROR in general.getLevelUpNames: " + err.stack);
+            return false;
+        }
+    };
+
+    general.isLoadout = function (name) {
+		if (!$u.isString(name) || name.indexOf('Loadout ') < 0) {
+			return false;
+		}
+		return name.replace('Loadout ','');
+    }
+
+    general.BuildLists = function () {
+        try {
+            var it = 0,
+                len = 0,
+                fullList = [],
+                generalList = [],
+				CoolDownNames = general.records.filter( function(r) {
+					return r.coolDown;
+				}).flatten('name').sort(),
+				defaultLoadout = config.getItem('Default Loadout', 'Use Current'),
+                usedGen = '',
+				uGR = {},
+				generalNames = [],
+                crossList = function (checkItem) {
+                    return generalList.hasIndexOf(checkItem) >= 0;
+                };
+
+            con.log(2, 'Building Generals Lists');
+			
+			['energy', 'stamina', 'health'].forEach(function(stat) {
+				stats[stat].min = 0;
+			});
+			
+			generalNames = general.records.flatten('name');
+
+			generalNames.forEach( function(n) {
+			    if (!general.isLoadout(n)) {
+                    general.GeneralsList.addToList(n);
+                } else {
+                    general.LoadoutsList.addToList(n);
+                }
+            });
+            general.GeneralsList = general.GeneralsList.sort();
+            fullList = general.LoadoutsList.concat(general.GeneralsList);
+            generalList = ['Under Level'].concat(fullList);
+
+            general.menuList.forEach(function(item) {
+                usedGen = config.getItem(item + 'General', 'Use Current');
+                if (['Use Current', 'Under Level', ''].indexOf(usedGen) == -1 && general.usedGenerals.indexOf(usedGen) == -1) {
+                    general.usedGenerals.addToList(usedGen);
+					uGR = general.getRecord(usedGen);
+					['energy', 'stamina', 'health'].forEach(function(stat) {
+						if (general.isLoadout(usedGen)) {
+							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat], 0));
+						} else if (defaultLoadout == 'Use Current') {
+							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat], 0));
+						} else {
+							stats[stat].min = Math.min(stats[stat].min, $u.setContent(uGR[stat] + general.getRecord(defaultLoadout)[stat], 0));
+						}
+						//con.log(2, 'Min loadout/general en/sta adjustment calc', uGR, stats[stat].min, stats[stat]);
+					});
+                }
+                general.lists[item] = ($u.isArray(general.filters[item]) && config.getItem("filterGeneral", true)) ? general.filters[item].filter(crossList) : generalList;
+            });
+
+            general.coolDownList = [''].concat(CoolDownNames);
+
+            con.log(2, 'Built lists', general.LoadoutsList, general.lists, general.usedGenerals);
+
+            return true;
+        } catch (err) {
+            con.error("ERROR in general.BuildLists: " + err.stack);
+            return false;
+        }
+    };
+
+    general.quickSwitch = false;
+    general.clickedLoadout = false;
+
+    general.assignStats = function (generalRecord, eatk, edef) {
+        try {
+            generalRecord.eatk = eatk;
+            generalRecord.edef = edef;
+            generalRecord.eapi = (generalRecord.eatk + (generalRecord.edef * 0.7)).dp(2);
+            generalRecord.edpi = (generalRecord.edef + (generalRecord.eatk * 0.7)).dp(2);
+            generalRecord.empi = ((generalRecord.eapi + generalRecord.edpi) / 2).dp(2);
+			['energy', 'stamina', 'health'].forEach(function(stat) {
+				if (stats[stat].norm && stats[stat].max) {
+					generalRecord[stat] = stats[stat].max - stats[stat].norm;
+					//con.log(2, 'Updated ' + stat + ' adjustement for ' + generalRecord.name + ' to ' + generalRecord[stat], generalRecord, stats[stat]);
+					if (general.usedGenerals.indexOf(generalRecord.name) > 0) {
+						stats[stat].min = Math.min(stats[stat].min, generalRecord[stat]);
+					}
+				}
+			});
+            generalRecord.last = Date.now();
+            caap.updateDashboard(true);
+            general.setRecord(generalRecord);
+            //con.log(2, "Got general stats for " + generalRecord.name, generalRecord);
+            return true;
+        } catch (err) {
+            con.error("ERROR in general.assignStats: " + err.stack);
+            return false;
+        }
+    }
 
     general.UpdateDropDowns = function () {
         try {
@@ -735,47 +771,10 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
         }
     };
 
-    general.getCurrentGeneral = function () {
-        try {
-            var generalName = $j('div[style*="hot_general_container.gif"] > div:first > div:nth-child(2), #equippedGeneralContainer div.general_name_div3').text().trim();
-            con.log(4, "Current General:", generalName);
-
-            if (!generalName) {
-                con.warn("Couldn't get current 'General'. Using 'Use Current'");
-                return 'Use Current';
-            }
-
-            return generalName;
-        } catch (err) {
-            con.error("ERROR in general.getCurrentGeneral: " + err.stack);
-            return 'Use Current';
-        }
-    };
-
-    general.getCurrentLoadout = function () {
-        try {
-            var loadoutName = $j('#hot_swap_loadouts_div select[name="choose_loadout"] option:selected').text().trim();
-
-            if (!loadoutName) {
-				if (stats.level < 101) {
-					return 'Loadouts Unavailable';
-				}
-                con.warn("Couldn't get current 'loadout'. Using 'Use Current'");
-                return 'Use Current';
-            }
-
-            //con.log(2, "Current Loadout:", loadoutName);
-            return "Loadout " + loadoutName;
-        } catch (err) {
-            con.error("ERROR in general.getCurrentLoadout: " + err.stack);
-            return 'Use Current';
-        }
-    };
-
 	// Provides lookup of a general equipped to a loadout. If general submitted, returns that general. If "Use Current," returns current general
     general.getLoadoutGeneral = function (name) {
 		name = general.isLoadout(name) ? general.getRecordVal(name, 'general') : name;
-		return name == 'Use Current' ? general.getCurrentGeneral() : name;
+		return name == 'Use Current' ? general.current : name;
     };
 
 	// Provides lookup of a general equipped to a menu general setting. If general submitted, returns that general. If "Use Current," returns current general
@@ -785,7 +784,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
     };
 
 	general.charged = function(name) {
-		var go = general.getRecord($u.isString(name) ? name : general.getCurrentGeneral());
+		var go = general.getRecord($u.isString(name) ? name : general.current);
 		return  !go.newRecord && go.coolDown ? schedule.since(go.charge, 0) : false;
 	};
 
@@ -860,7 +859,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 	general.changeStatCheck = function(g) { //target general, current general
 		return ['stamina', 'energy'].reduce( function(p, s) {
 			var nextGenS = general.getRecordVal(g, s),
-				curGenS = general.getRecordVal(general.getCurrentGeneral(), s);
+				curGenS = general.getRecordVal(general.current, s);
 			if (nextGenS < curGenS && stats[s].num > stats[s].norm + nextGenS) {
 				con.warn('Overrode general change to ' + g + ' because ' + stats[s].num + ' ' + s + ' greater than max ' + stats[s].norm + ' plus general mod of  ' + nextGenS);
 				return true;
@@ -873,10 +872,10 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 	general.logGeneral = function(isLoadout) { //general or Loadout
 		if (config.getItem('IdleGeneral', 'Use Current') != 'Use Current') {
 			if (isLoadout && state.getItem('lastLoadout', 'Use Current') == 'Use Current') {
-				state.setItem('lastLoadout', general.getCurrentGeneral());
+				state.setItem('lastLoadout', general.current);
 			}
 			if (state.getItem('lastGeneral', 'Use Current') == 'Use Current') {
-				state.setItem('lastGeneral', general.getCurrentLoadout());
+				state.setItem('lastGeneral', general.loadout);
 			}
 		}
 	};
@@ -892,13 +891,11 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 				resultFalse = returnNametf ? targetGeneral : false,
 				freezeTf = resultFalse,
                 lRecord = {},
-                currentGeneral = general.getCurrentGeneral(),
-                currentLoadout = general.getCurrentLoadout(),
 				cgR = {}, // current general record
                 defaultLoadout = config.getItem("DefaultLoadout", 'Use Current');
 			
 			targetGeneral = $u.setContent(targetGeneral, 'Use Current');
-			if (!general.hasRecord(currentGeneral) && !returnNametf) {
+			if (!general.hasRecord(general.current) && !returnNametf) {
 				con.warn('Current general unknown. Going to generals page to get general records.');
 				if (caap.navigateTo('generals')) {
 					return true;
@@ -906,7 +903,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 				return caap.navigateTo('keep');
 			}
 
-            if (timedGeneral && timedGeneral != targetGeneral && (targetGeneral != 'Use Current' || currentGeneral != timedGeneral)) {
+            if (timedGeneral && timedGeneral != targetGeneral && (targetGeneral != 'Use Current' || general.current != timedGeneral)) {
 				freezeTf = config.getItem('timedFreeze', true);
                 con.log(2,'General change to ' + targetGeneral + (freezeTf ? '. Script paused' : ' ignored') + ' while equipping timed general ' + timedGeneral);
                 targetGeneral = timedGeneral;
@@ -926,7 +923,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
             // Confirm loadout is ok
 			if (stats.level > 100) {
 				targetLoadout = general.isLoadout(targetGeneral) ? targetGeneral : defaultLoadout;
-				targetLoadout = (targetLoadout === "Use Current") ? currentLoadout : targetLoadout;
+				targetLoadout = (targetLoadout === "Use Current") ? general.loadout : targetLoadout;
 				lRecord = general.getRecord(targetLoadout);
 				if (lRecord.newRecord) {
 					con.warn('Unable to find ' + targetLoadout + ' record. Loadouts reset? Ignoring setting.');
@@ -936,16 +933,17 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 					if (general.changeStatCheck(targetLoadout)) {
 						con.log(1, 'Overriding loadout change to ' + targetLoadout + ' since it would cause stat loss');
 					} else if (general.clickedLoadout !== false) {
-						general.records[general.clickedLoadout].general = currentGeneral;
+						general.records[general.clickedLoadout].general = general.current;
 						general.clickedLoadout = false;
-					} else if (targetLoadout !== currentLoadout || (targetLoadout == currentLoadout && lRecord.general == targetGeneral
-						&& currentGeneral !== targetGeneral && targetGeneral !== 'Use Current')) {
+					} else if (targetLoadout !== general.loadout || (targetLoadout == general.loadout && lRecord.general == targetGeneral
+						&& general.current !== targetGeneral && targetGeneral !== 'Use Current')) {
 						if (returnNametf) {
 							return targetLoadout;
 						}
 						con.log(2,'Loading ' + targetLoadout + ' loadout #' + lRecord.value, lRecord);
 						
 						general.logGeneral(true);
+						general.quickSwitch = true;
 						general.clickedLoadout = lRecord.value - 1;
 						caap.click($j('div[id*="hot_swap_loadouts_content_div"] > div:nth-child(' + lRecord.value + ') > div:first'));
 						return resultTrue;
@@ -954,19 +952,19 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 			}
 			
             // Confirm if necessary to load a different general
-            if (targetGeneral === currentGeneral || targetGeneral === 'Use Current') {
+            if (targetGeneral === general.current || targetGeneral === 'Use Current') {
                 return resultFalse;
             }
 
 			if (general.changeStatCheck(targetGeneral)) {
 				con.log(1, 'Overriding general change to ' + targetGeneral + ' since it would cause stat loss');
-				return returnNametf ? currentGeneral : freezeTf;
+				return returnNametf ? general.current : freezeTf;
 			}
 			if (returnNametf) {
 				return targetGeneral;
 			}
 			
-            con.log(2, 'Changing from ' + currentGeneral + ' to ' + targetGeneral);
+            con.log(2, 'Changing from ' + general.current + ' to ' + targetGeneral);
             if (caap.navigateTo('generals')) {
                 return resultTrue;
             }

--- a/Chrome/unpacked/js/worker_gsheet.js
+++ b/Chrome/unpacked/js/worker_gsheet.js
@@ -1,0 +1,97 @@
+/*jslint white: true, browser: true, devel: true, undef: true,
+nomen: true, bitwise: true, plusplus: true,
+regexp: true, eqeq: true, newcap: true, forin: false */
+/*global window,escape,jQuery,$j,rison,utility,offline,town,
+$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,gsheet,ss,
+schedule,gifting,state,army, general,session,monster,guild_monster */
+/*jslint maxlen: 256 */
+
+////////////////////////////////////////////////////////////////////
+//                          gsheet OBJECT
+// this is the main object for dealing with gsheet items
+/////////////////////////////////////////////////////////////////////
+
+(function () {
+    "use strict";
+
+	worker.add('gsheet');
+	
+	chrome.runtime.sendMessage({method: "getLocalStorage", key: "caweb3gsheet"}, function(response) {
+		gsheet.tableId = response.data;
+	});
+
+	chrome.runtime.sendMessage({method: "getLocalStorage", key: "caweb3salt"}, function(response) {
+		gsheet.salt = $u.setContent(response.data, '');
+	});
+	
+    gsheet.init = function () {
+        try {
+            if(![0, 2].hasIndexOf(caap.domain.which)) {
+                return true;
+            }
+			
+			if (!$u.hasContent(gsheet.tableId)) {
+				con.log(2, 'No google sheet configured to set config variables. Configurable in the CAAP options page.');
+				return;
+			}
+			if (!$u.hasContent(gsheet.salt)) {
+				con.log(2, 'No salt string given to disguise FB ID MD5 hash');
+			}
+			
+			var hash = (stats.FBID + gsheet.salt).MD5(),
+				url = 'https://docs.google.com/spreadsheets/d/' + gsheet.tableId + '/gviz/tq?tqx=out:json&tq=' + encodeURIComponent("select * where B = '" + hash + "'");
+
+            con.log(2, "gsheet: Loading google data sheet ID " + gsheet.tableId + " with hash "  + hash);
+			
+			$j.ajax({
+				url: url,
+				dataType: 'text',
+				error: function (XMLHttpRequest, textStatus, errorThrown) {
+					con.error("gsheet.load error: using saved values", XMLHttpRequest, textStatus, errorThrown);
+				},
+				success: function (data) {
+					try {
+						con.log(2, "gsheet.init data received", data);
+						var obj = {},
+							label = '',
+							values = [],
+							oldVal = 'defaultX',
+							newVal = 'defaultX';
+
+						obj = JSON.parse($u.setContent(data.regex(/\((.*)\)/), '{}'));
+						// If JSON parse fails, the error will be caught below
+						
+						if (!$u.hasContent(obj.table) || !$u.hasContent(obj.table.rows)) {
+							con.log(1, 'Gsheet: no match for hash ' + hash + ' found on URL ' + url, data, obj);
+							return;
+						} else if (obj.table.rows.length != 1) {
+							con.log(1, 'Gsheet: too many matches for hash ' + hash + ' found on URL ' + url, data, obj);
+							return;
+						}
+						
+						values = obj.table.rows[0].c;
+							
+						obj.table.cols.forEach( function(c, i) {
+							label = $u.setContent(c.label, '').trim();
+							oldVal = $u.hasContent(label) ? config.getItem(label, 'defaultx') : null;
+							oldVal = oldVal == 'defaultx' ? null : oldVal;
+							newVal = !$u.hasContent(values[i]) || !$u.hasContent(values[i].v) ? null : values[i].v;
+							if (oldVal !== null && newVal !== null && oldVal != newVal) {
+								con.log(1, 'Gsheet: Updating config value of ' + label + ' from ' + oldVal
+									+ ' to ' + config.setItem(label, newVal));
+							}
+						});
+						con.log(2, 'Gsheet configs completed', obj);
+					} catch (err) {
+						con.error("1:ERROR in gsheet.init: " + err.stack);
+					}
+				}
+			});
+            return true;
+        } catch (err) {
+            con.error("2:ERROR in gsheet.init: " + err.stack);
+            return false;
+        }
+    };
+
+}());

--- a/Chrome/unpacked/js/worker_loe.js
+++ b/Chrome/unpacked/js/worker_loe.js
@@ -185,8 +185,8 @@ schedule,gifting,state,army, general,session,battle:true,guild_battle: true */
 				+ ',clickjq:div[onclick^="towerTabClick(' + "'" + n + "'" + ')"]:visible,jq:#tower_' 
 				+ n + ':visible,clickjq:.action_panel_' + t.id + ' input[src*="' + t.attack + '.jpg"]');
 			if (result == 'fail') {
-				con.warn(stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.getCurrentGeneral() + ' has ' + t.attack + ', reloading page', general.getCurrentGeneral(), general.getCurrentLoadout());
-				caap.setDivContent(mess, stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.getCurrentGeneral() + ' has ' + t.attack);
+				con.warn(stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack + ', reloading page', general.current, general.loadout);
+				caap.setDivContent(mess, stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack);
 				gb.setRecord(fR);
 				return caap.navigate2('ajax:guild_conquest_castle_battlelist.php');
 			} else if (result == 'done') {

--- a/Chrome/unpacked/js/worker_monster.js
+++ b/Chrome/unpacked/js/worker_monster.js
@@ -1330,7 +1330,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster */
 					statRequire = caap.minMaxArray(statList, minMax, 1, (statAvailable + 1) / gMult) * gMult ;
 				}
 				if (statRequire && statRequire <= statAvailable) {
-					nodeNum = !cM.multiNode ? 0 : statList.indexOf(statRequire.toString());
+					nodeNum = !cM.multiNode ? 0 : statList.indexOf((statRequire / gMult).toString());
 					con.log(2, 'NodeNum ' + nodeNum);
 					return true;
 				} else {

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -19,175 +19,182 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
     statsFunc.record = function (FBID) {
         this.data = {
-			'FBID': FBID,
-			'account': '',
-			'PlayerName': '',
-			'level': 0,
-			'army': {
-				'actual': 0,
-				'capped': 0
+			FBID: FBID,
+			account: '',
+			PlayerName: '',
+			level: 0,
+			army: {
+				actual: 0,
+				capped: 0
 			},
-			'records': {
-				'total': 0,
-				'invade': 0
+			records: {
+				total: 0,
+				invade: 0
 			},
-			'attack': 0,
-			'defense': 0,
-			'bonus' : {
-				'attack': 0,
-				'defense': 0,
-				'dpi' : 0,
-				'api' : 0
+			attack: 0,
+			defense: 0,
+			bonus: {
+				attack: 0,
+				defense: 0,
+				dpi: 0,
+				api: 0
 			},
-			'points': {
-				'skill': 0,
-				'favor': 0,
-				'guild': 0
+			points: {
+				skill: 0,
+				favor: 0,
+				guild: 0
 			},
-			'indicators': {
-				'bsi': 0,
-				'lsi': 0,
-				'sppl': 0,
-				'api': 0,
-				'dpi': 0,
-				'mpi': 0,
-				'mhbeq': 0,
-				'htl': 0,
-				'hrtl': 0,
-				'enl': 0,
-				'pvpclass': '',
-				'build': ''
+			indicators: {
+				bsi: 0,
+				lsi: 0,
+				sppl: 0,
+				api: 0,
+				dpi: 0,
+				mpi: 0,
+				mhbeq: 0,
+				htl: 0,
+				hrtl: 0,
+				enl: 0,
+				pvpclass: '',
+				build: ''
 			},
-			'gold': {
-				'cash': 0,
-				'bank': 0,
-				'total': 0,
-				'income': 0,
-				'upkeep': 0,
-				'flow': 0,
-				'ticker': []
+			gold: {
+				cash: 0,
+				bank: 0,
+				total: 0,
+				income: 0,
+				upkeep: 0,
+				flow: 0,
+				ticker: []
 			},
-			'rank': {
-				'battle': 0,
-				'battlePoints': 0,
-				'war': 0,
-				'warPoints': 0,
-				'conquest': 0,
-				'conquestPoints': 0,
-				'conquestLevel': 0,
-				'conquestLevelPercent': 0
+			rank: {
+				battle: 0,
+				battlePoints: 0,
+				war: 0,
+				warPoints: 0,
+				conquest: 0,
+				conquestPoints: 0,
+				conquestLevel: 0,
+				conquestLevelPercent: 0
 			},
-			'potions': {
-				'energy': 0,
-				'stamina': 0
+			potions: {
+				energy: 0,
+				stamina: 0
 			},
-			'energy': {
-				'norm': 0,
-				'num': 0,
-				'min': 0,
-				'max': 0,
-				'ticker': []
+			energy: {
+				norm: 0,
+				num: 0,
+				min: 0,
+				max: 0,
+				ticker: []
 			},
-			'health': {
-				'norm': 0,
-				'num': 0,
-				'min': 0,
-				'max': 0,
-				'ticker': []
+			health: {
+				norm: 0,
+				num: 0,
+				min: 0,
+				max: 0,
+				ticker: []
 			},
-			'stamina': {
-				'norm': 0,
-				'num': 0,
-				'min': 0,
-				'max': 0,
-				'ticker': []
+			stamina: {
+				norm: 0,
+				num: 0,
+				min: 0,
+				max: 0,
+				ticker: []
 			},
-			'lowpoints' : {
-				'level' : 0,
-				'stamina' : 0,
-				'energy' : 0
+			lowpoints: {
+				level: 0,
+				stamina: 0,
+				energy: 0
 			},
-			'exp': {
-				'num': 0,
-				'max': 0,
-				'dif': 0
+			exp: {
+				num: 0,
+				max: 0,
+				dif: 0
 			},
-			'guildTokens': {
-				'num': 0,
-				'max': 0,
-				'dif': 0
+			guildTokens: {
+				num: 0,
+				max: 0,
+				dif: 0
 			},
-			'resources': {
-				'lumber': 0,
-				'iron': 0
+			resources: {
+				lumber: 0,
+				iron: 0
 			},
-			'conquest': {
-				'Conqueror': 0,
-				'Guardian': 0,
-				'Hunter': 0,
-				'Engineer': 0
+			conquest: {
+				Conqueror: 0,
+				Guardian: 0,
+				Hunter: 0,
+				Engineer: 0
 			},
-			'LoMland' : -1,
-			'other': {
-				'qc': 0,
-				'bww': 0,
-				'bwl': 0,
-				'te': 0,
-				'tee': 0,
-				'wlr': 0,
-				'eer': 0,
-				'atlantis': false
+			LoMland: -1,
+			other: {
+				qc: 0,
+				bww: 0,
+				bwl: 0,
+				te: 0,
+				tee: 0,
+				wlr: 0,
+				eer: 0,
+				atlantis: false
 			},
-			'achievements': {
-				'battle': {
-					'invasions': {
-						'won': 0,
-						'lost': 0,
-						'streak': 0,
-						'ratio': 0
+			achievements: {
+				battle: {
+					invasions: {
+						won: 0,
+						lost: 0,
+						streak: 0,
+						ratio: 0
 					},
-					'duels': {
-						'won': 0,
-						'lost': 0,
-						'streak': 0,
-						'ratio': 0
+					duels: {
+						won: 0,
+						lost: 0,
+						streak: 0,
+						ratio: 0
 					}
 				},
-				'monster': {},
-				'other': {
-					'alchemy': 0
+				monster: {},
+				other: {
+					alchemy: 0
 				},
-				'feats': {
-					'attack': 0,
-					'defense': 0,
-					'health': 0,
-					'energy': 0,
-					'stamina': 0,
-					'army': 0
+				feats: {
+					attack: 0,
+					defense: 0,
+					health: 0,
+					energy: 0,
+					stamina: 0,
+					army: 0
 				}
 			},
-			'character': {},
-			'guild': {
-				'name': '',
-				'id': '',
-				'ids' : [], // For your guild mates
-				'level': 0,
-				'levelPercent': 0,
-				'mPoints': 0,
-				'mRank': '',
-				'bPoints': 0,
-				'bRank': '',
-				'members': []
+			character: {},
+			guild: {
+				name: '',
+				id: '',
+				ids: [], // For your guild mates
+				level: 0,
+				levelPercent: 0,
+				mPoints: 0,
+				mRank: '',
+				bPoints: 0,
+				bRank: '',
+				powers: '',
+				members: []
 			},
-			'battleIdle' : 'Use Current',
+			battleIdle: 'Use Current',
 			reviewPages : [],
-			'essence' : {
-				'attack': 0,
-				'defense' : 0,
-				'damage' : 0,
-				'health' : 0
+			rune: {
+				attack: 0,
+				defense: 0,
+				damage: 0,
+				health: 0
 			},
-			'priorityGeneral' : 'Use Current'
+			essence: {
+				attack: 0,
+				defense: 0,
+				damage: 0,
+				health: 0
+			},
+			priorityGeneral: 'Use Current'
 		};
     };
 
@@ -310,11 +317,502 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
             return passed;
         } catch (err) {
-            con.error("ERROR in stats.checkResults: " + err.stack);
+            con.error("ERROR in stats.check: " + err.stack);
             return false;
         }
     };
 
+    stats.checkResults = function (page) {
+        try {
+			switch (page) {
+			case 'keep' :
+				var attrDiv = $j("#app_body #keepAltStats"),
+					statsTB = $j("#app_body div[style*='keep_cont_treasure.jpg'] div:nth-child(3)>div>div>div>div"),
+					//keepTable1 = $j("#app_body .keepTable1 tr"),
+					statCont = $j("#app_body div[style*='keep_bgv2.jpg']>div>div>div"),
+					recordsTxt = $j(),
+					args = [],
+					backgroundDiv = $j(),
+					tempDiv = $j(),
+					temp,
+					row,
+					head,
+					body;
+
+				if ($u.hasContent(attrDiv)) {
+					con.log(2, "Getting new values from player keep");
+					// rank
+					tempDiv = $j("#app_body img[src*='gif/rank']");
+					if ($u.hasContent(tempDiv)) {
+						stats.rank.battle = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
+					} else {
+						con.warn('Using stored rank.');
+					}
+
+					// PlayerName
+					tempDiv = $j("#app_body div[style*='keep_top.jpg'] div").first();
+					if ($u.hasContent(tempDiv)) {
+						stats.PlayerName = tempDiv.text().trim();
+						//con.log(1, stats.PlayerName);
+					} else {
+						con.warn('Using stored PlayerName.');
+					}
+
+					// FBID
+					tempDiv = $j("#app_body a[href*='keep.php?user=']");
+					if ($u.hasContent(tempDiv)) {
+						stats.FBID = tempDiv.attr("href").basename().regex(/(\d+)/);
+						//con.log(1, stats.FBID);
+					} else {
+						con.warn('Using stored PlayerName.');
+					}
+
+					// war rank
+					if (stats.level >= 100) {
+						tempDiv = $j("#app_body img[src*='war_rank_']");
+						if ($u.hasContent(tempDiv)) {
+							stats.rank.war = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
+						} else {
+							con.warn('Using stored warRank.');
+						}
+					}
+					// conquest rank
+					if (stats.level >= 100) {
+						tempDiv = $j("#app_body img[src*='conquest_rank_']");
+						if ($u.hasContent(tempDiv)) {
+							stats.rank.conquest = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
+						} else {
+							con.warn('Using stored conquestRank.');
+						}
+					}
+
+					if ($u.hasContent(statCont) && statCont.length >= 6) {
+						if (stats.level >= 10) {
+							// Attack
+							tempDiv = statCont.eq(2);
+							if ($u.hasContent(tempDiv)) {
+								stats.attack = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
+								stats.bonus.attack = $u.setContent($u.setContent(tempDiv.text(), '').regex(/\(\+(\d+)\)/), 0);
+								//con.log(2,'KEEP Attack', stats.attack, stats.attackbonus);
+							} else {
+								con.warn('Using stored attack value.');
+							}
+
+							// Defense
+							tempDiv = statCont.eq(3);
+							if ($u.hasContent(tempDiv)) {
+								stats.defense = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
+								stats.bonus.defense = $u.setContent($u.setContent(tempDiv.text(), '').regex(/\(\+(\d+)\)/), 0);
+								//con.log(2,'KEEP Defense', stats.defense, stats.defensebonus);
+							} else {
+								con.warn('Using stored defense value.');
+							}
+						}
+
+						// Health
+						tempDiv = statCont.eq(4);
+						if ($u.hasContent(tempDiv)) {
+							stats.health.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
+							
+						} else {
+							con.warn('Unable to find unadjusted Health value.');
+						}
+						
+						// Energy
+						tempDiv = statCont.eq(0);
+						if ($u.hasContent(tempDiv)) {
+							stats.energy.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
+						} else {
+							con.warn('Unable to find unadjusted Energy value.');
+						}
+
+						// Stamina
+						tempDiv = statCont.eq(1);
+						if ($u.hasContent(tempDiv)) {
+							stats.stamina.norm = $u.setContent($u.setContent(tempDiv.text(), '').regex(/(\d+)/), 0);
+						} else {
+							con.warn('Unable to find unadjusted Stamina value.');
+						}
+					} else {
+						con.warn("Can't find stats containers! Using stored stats values.");
+					}
+
+					// Check for Gold Stored
+					tempDiv = statsTB.eq(4);
+					if ($u.hasContent(tempDiv)) {
+						stats.gold.bank = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
+						stats.gold.total = stats.gold.bank + stats.gold.cash;
+						tempDiv.attr({
+							title: "Click to copy value to retrieve"
+						}).css({
+							color: "blue",
+							cursor: "pointer"
+						}).on("click", function () {
+							$j("#app_body #getGold").val(stats.gold.bank);
+						});
+					} else {
+						con.warn('Using stored inStore.');
+					}
+
+					// Check for income
+					tempDiv = statsTB.eq(5);
+					if ($u.hasContent(tempDiv)) {
+						stats.gold.income = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
+					} else {
+						con.warn('Using stored income.');
+					}
+
+					// Check for upkeep
+					tempDiv = statsTB.eq(6);
+					if ($u.hasContent(tempDiv)) {
+						stats.gold.upkeep = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
+					} else {
+						con.warn('Using stored upkeep.');
+					}
+
+					// Cash Flow
+					stats.gold.flow = stats.gold.income - stats.gold.upkeep;
+
+					// Energy potions
+					tempDiv = $j("div[title='Energy Potion']").children().eq(1);
+					if ($u.hasContent(tempDiv)) {
+						stats.potions.energy = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
+					} else {
+						stats.potions.energy = 0;
+					}
+
+					// Stamina potions
+					tempDiv = $j("div[title='Stamina Potion']").children().eq(1);
+					if ($u.hasContent(tempDiv)) {
+						stats.potions.stamina = $u.setContent($u.setContent(tempDiv.text(), '').numberOnly(), 0);
+					} else {
+						stats.potions.stamina = 0;
+					}
+
+					// Other stats
+					// Atlantis Open
+					stats.other.atlantis = $u.hasContent(caap.checkForImage("seamonster_map_finished.jpg")) ? true : false;
+
+					recordsTxt = $u.setContent($j("#globalContainer #records_tab").text().trim().innerTrim(), '');
+					args = recordsTxt.match(new RegExp("Quests Completed (\\d+) Battles/Wars Won (\\d+) Battles/Wars Lost (\\d+) Kills (\\d+) Deaths (\\d+)"));
+					if (args && args.length === 6) {
+						stats.other.qc = args[1].numberOnly();
+						stats.other.bww = args[2].numberOnly();
+						stats.other.bwl = args[3].numberOnly();
+						stats.other.te = args[4].numberOnly();
+						stats.other.tee = args[5].numberOnly();
+						//con.log(2, "my stats", args, recordsTxt, stats.other);
+					} else {
+						con.warn("Unable to read quests completed and battle stats", args, recordsTxt);
+					}
+
+					// Win/Loss Ratio (WLR)
+					stats.other.wlr = stats.other.bwl !== 0 ? (stats.other.bww / stats.other.bwl).dp(2) : Infinity;
+					// Enemy Eliminated Ratio/Eliminated (EER)
+					stats.other.eer = stats.other.tee !== 0 ? (stats.other.tee / stats.other.te).dp(2) : Infinity;
+					// Indicators
+					if (stats.level >= 10) {
+						stats.indicators.bsi = ((stats.attack + stats.defense) / stats.level).dp(2);
+						stats.indicators.lsi = ((stats.energy.max + (2 * stats.stamina.max)) / stats.level).dp(2);
+						stats.indicators.sppl = ((stats.energy.max + (2 * stats.stamina.max) + stats.attack + stats.defense + stats.health.max - 122) / stats.level).dp(2);
+						stats.indicators.api = (stats.attack + (stats.defense * 0.7)).dp(0);
+						stats.bonus.api = stats.indicators.api + (stats.bonus.attack + (stats.bonus.defense * 0.7)).dp(0);
+						stats.indicators.dpi = ((stats.defense + (stats.attack * 0.7))).dp(0);
+						stats.bonus.dpi = stats.indicators.dpi + (stats.bonus.defense + (stats.bonus.attack * 0.7)).dp(0);
+						stats.indicators.mpi = (((stats.indicators.api + stats.indicators.dpi) / 2)).dp(0);
+						stats.indicators.mhbeq = ((stats.attack + (2 * stats.stamina.max)) / stats.level).dp(2);
+						if (stats.attack >= stats.defense) {
+							temp = stats.attack / stats.defense;
+							if (temp === stats.attack) {
+								stats.indicators.pvpclass = 'Destroyer';
+							} else if (temp >= 2 && temp < 7.5) {
+								stats.indicators.pvpclass = 'Aggressor';
+							} else if (temp < 2 && temp > 1.01) {
+								stats.indicators.pvpclass = 'Offensive';
+							} else if (temp <= 1.01) {
+								stats.indicators.pvpclass = 'Balanced';
+							}
+						} else {
+							temp = stats.defense / stats.attack;
+							if (temp === stats.defense) {
+								stats.indicators.pvpclass = 'Wall';
+							} else if (temp >= 2 && temp < 7.5) {
+								stats.indicators.pvpclass = 'Paladin';
+							} else if (temp < 2 && temp > 1.01) {
+								stats.indicators.pvpclass = 'Defensive';
+							} else if (temp <= 1.01) {
+								stats.indicators.pvpclass = 'Balanced';
+							}
+						}
+					}
+
+					// added rune totals
+					temp = $j('#runes_2').text().trim().innerTrim();
+					caap.bulkRegex(temp, / (\d+).*Atk.* (\d+).*Def.* (\d+).*Dmg.* (\d+).*Hth/, stats.rune, ['attack', 'defense', 'damage', 'health']);
+					caap.bulkRegex(temp, /x(\d+) x(\d+) x(\d+) x(\d+)/, stats.essence, ['Attack', 'Defense', 'Damage', 'Health']);
+
+					statsFunc.setRecord(stats);
+					if (config.getItem("displayKStats", true)) {
+						tempDiv = $j("div[style*='keep_top']");
+						backgroundDiv = $j("div[style*='keep_tabheader']");
+
+						temp = "<div style='background-image:url(\"" + caap.domain.protocol[caap.domain.ptype] +"castleagegame1-a.akamaihd.net/30966/graphics/keep_tabsubheader_mid.jpg\");border:none;padding: 5px 5px 20px 20px;width:715px;font-weight:bold;font-family:Verdana;sans-serif;background-repeat:y-repeat;'>";
+						temp += "<div style='border:1px solid #701919;padding: 5px 5px;width:688px;height:100px;background-color:#d0b682;'>";
+						row = caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '5%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '10%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '20%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '10%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '20%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '10%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '20%'
+						});
+
+						row += caap.makeTh({
+							text: '&nbsp;',
+							color: '',
+							bgcolor: '',
+							id: '',
+							title: '',
+							width: '5%'
+						});
+
+						head = caap.makeTr(row);
+
+						row = caap.makeTd({
+							text: '',
+							color: '',
+							id: '',
+							title: ''
+						});
+
+						row += caap.makeTd({
+							text: 'BSI',
+							color: '',
+							id: '',
+							title: 'Battle Strength Index'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.bsi,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'LSI',
+							color: '',
+							id: '',
+							title: 'Leveling Speed Index'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.lsi,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'SPPL',
+							color: '',
+							id: '',
+							title: 'Skill Points Per Level (More accurate than SPAEQ)'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.sppl,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						body = caap.makeTr(row);
+
+						row = caap.makeTd({
+							text: '',
+							color: '',
+							id: '',
+							title: ''
+						});
+
+						row += caap.makeTd({
+							text: 'API',
+							color: '',
+							id: '',
+							title: 'Attack Power Index'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.api,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'DPI',
+							color: '',
+							id: '',
+							title: 'Defense Power Index'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.dpi,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'MPI',
+							color: '',
+							id: '',
+							title: 'Mean Power Index'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.mpi,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						body += caap.makeTr(row);
+
+						row = caap.makeTd({
+							text: '',
+							color: '',
+							id: '',
+							title: ''
+						});
+
+						row += caap.makeTd({
+							text: 'MHBEQ',
+							color: '',
+							id: '',
+							title: 'Monster Hunting Build Effective Quotent'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.mhbeq,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'Build',
+							color: '',
+							id: '',
+							title: 'Character build type'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.build,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: 'PvP Class',
+							color: '',
+							id: '',
+							title: 'Player vs. Player character class'
+						}, "font-size:14px;");
+
+						row += caap.makeTd({
+							text: stats.indicators.pvpclass,
+							color: '',
+							id: '',
+							title: ''
+						}, "font-size:14px;");
+
+						body += caap.makeTr(row);
+
+						temp += caap.makeTable("keepstats", head, body, "Statistics", "font-size:16px;");
+						temp += "</div></div>";
+						tempDiv.after(temp);
+					} else {
+						tempDiv = $j(".keep_stat_title_inc", attrDiv);
+						tempDiv = $u.hasContent(tempDiv) ? tempDiv.html($u.setContent(tempDiv.html(), '').trim() + ", <span style='white-space: nowrap;'>BSI: " +
+							stats.indicators.bsi + " LSI: " + stats.indicators.lsi + "</span>") : tempDiv;
+					}
+				} else {
+					tempDiv = $j("#app_body a[href*='keep.php?user=']");
+					if ($u.hasContent(tempDiv)) {
+						con.log(2, "On another player's keep", $u.setContent($u.setContent(tempDiv.attr("href"), '').basename().regex(/(\d+)/), 0));
+					} else {
+						con.warn("Attribute section not found and not identified as another player's keep!");
+					}
+				}
+				break;
+			default :
+				break;
+			}
+
+            return true;
+        } catch (err) {
+            con.error("ERROR in stats.checkResults: " + err.stack);
+            return false;
+        }
+    };
+	
     statsFunc.dashboard = function() {
         try {
             var headers = [],

--- a/Chrome/unpacked/manifest.json
+++ b/Chrome/unpacked/manifest.json
@@ -12,7 +12,7 @@
       "all_frames": true,
       "exclude_globs": [ "http://apps.facebook.com/castle_age/festival_hod.php", "https://apps.facebook.com/castle_age/festival_hod.php", "http://web3.castleagegame.com/castle_ws/festival_hod.php", "https://web3.castleagegame.com/castle_ws/festival_hod.php" ],
       "include_globs": [ "http://apps.facebook.com/castle_age/*", "https://apps.facebook.com/castle_age/*", "http://web3.castleagegame.com/castle_ws/*", "https://web3.castleagegame.com/castle_ws/*", "http://apps.facebook.com/reqs.php#confirm_46755028429_0*", "https://apps.facebook.com/reqs.php#confirm_46755028429_0*", "http://*.facebook.com/common/error.html*", "https://*.facebook.com/common/error.html*", "http://apps.facebook.com/sorry.php*", "https://apps.facebook.com/sorry.php*", "http://web.castleagegame.com/castle/*", "https://web.castleagegame.com/castle/*", "http://webback.castleagegame.com/castle/*", "https://webback.castleagegame.com/castle/*", "http://www.facebook.com/dialog/apprequests*", "http://apps.facebook.com/fbml/ajax/dialog/apprequests", "https://www.facebook.com/dialog/apprequests*" ],
-      "js": [ "extern/jquery.js", "extern/jqueryui.js", "extern/farbtastic.min.js", "extern/jquery.dataTables.js", "extern/utility.js", "js/head.js", "js/worker.js", "js/image64.js", "js/offline.js", "js/profiles.js", "js/css.js", "js/sort.js", "js/worker_stats.js", "js/worker_general.js", "js/worker_monster.js", "js/worker_guild_monster.js", "js/worker_gb.js", "js/worker_feed.js", "js/worker_battle.js", "js/worker_town.js", "js/worker_army.js", "js/worker_chores.js", "js/worker_gifting.js", "js/worker_demi.js", "js/worker_conquest.js", "js/worker_loe.js", "js/worker_recon.js", "js/worker_caap.js", "js/caap_base.js", "js/caap_display.js", "js/caap_jquery.js", "js/caap_mainloop.js", "js/caap_dashboard.js", "js/caap_navigation.js", "js/caap_start.js", "js/functions.js", "js/spreadsheet.js", "js/begin.js"],
+      "js": [ "extern/jquery.js", "extern/jqueryui.js", "extern/farbtastic.min.js", "extern/jquery.dataTables.js", "extern/utility.js", "js/head.js", "js/worker.js", "js/image64.js", "js/offline.js", "js/profiles.js", "js/css.js", "js/sort.js", "js/worker_gsheet.js", "js/worker_stats.js", "js/worker_general.js", "js/worker_monster.js", "js/worker_guild_monster.js", "js/worker_gb.js", "js/worker_feed.js", "js/worker_battle.js", "js/worker_town.js", "js/worker_army.js", "js/worker_chores.js", "js/worker_gifting.js", "js/worker_demi.js", "js/worker_conquest.js", "js/worker_loe.js", "js/worker_recon.js", "js/worker_caap.js", "js/caap_base.js", "js/caap_display.js", "js/caap_jquery.js", "js/caap_mainloop.js", "js/caap_dashboard.js", "js/caap_navigation.js", "js/caap_start.js", "js/functions.js", "js/spreadsheet.js", "js/begin.js"],
       "matches": [ "http://*/*", "https://*/*" ]
    } ],
    "converted_from_user_script": false,
@@ -46,6 +46,7 @@
 					"http://www.facebook.com/dialog/apprequests*", 
 					"https://www.facebook.com/dialog/apprequests*", 
 					"http://apps.facebook.com/fbml/ajax/dialog/apprequests", 
+					"https://www.googleapis.com/fusiontables/*", 
 					"http://query.yahooapis.com/v1/public/yql*" ],
    "update_url": "https://raw.github.com/magowiz/Castle-Age-Autoplayer/master/Chrome/packed/updates.xml",
    "version": "141.0.0.264"

--- a/Chrome/unpacked/options.html
+++ b/Chrome/unpacked/options.html
@@ -16,10 +16,16 @@
 			<table class="web3tbl">
 			<tbody>
 			<tr style="height:35px;">
-			<td><label>email : <input type="email" id="caWeb3Email" value="" size="4" style="width:300px"></label></td>
+			<td><label>Email : <input type="email" id="caweb3email" value="" size="4" style="width:300px"></label></td>
 			</tr>
 			<tr style="height:35px;">
-			<td><label>password : <input type="password" id="caWeb3Password" value="" size="4" style="width:300px"></label></td>
+			<td><label>Password : <input type="password" id="caweb3password" value="" size="4" style="width:300px"></label></td>
+			</tr>
+			<tr style="height:35px;">
+			<td><label>Google Sheet ID: <input type="text" id="caweb3gsheet" value="" size="4" style="width:300px"></label></td>
+			</tr>
+			<tr style="height:35px;">
+			<td><label>Hash Salt: <input type="text" id="caweb3salt" value="" size="4" style="width:300px"></label></td>
 			</tr>
 			</tbody>
 			</table>

--- a/Chrome/unpacked/popup.html
+++ b/Chrome/unpacked/popup.html
@@ -16,10 +16,16 @@
 			<table class="web3tbl">
 			<tbody>
 			<tr style="height:35px;">
-			<td><label>email : <input type="email" id="caWeb3Email" value="" size="4" style="width:300px"></label></td>
+			<td><label>Email : <input type="email" id="caweb3email" value="" size="4" style="width:300px"></label></td>
 			</tr>
 			<tr style="height:35px;">
-			<td><label>password : <input type="password" id="caWeb3Password" value="" size="4" style="width:300px"></label></td>
+			<td><label>Password : <input type="password" id="caweb3password" value="" size="4" style="width:300px"></label></td>
+			</tr>
+			<tr style="height:35px;">
+			<td><label>Google Sheet ID: <input type="text" id="caweb3gsheet" value="" size="4" style="width:300px"></label></td>
+			</tr>
+			<tr style="height:35px;">
+			<td><label>Hash Salt: <input type="text" id="caweb3salt" value="" size="4" style="width:300px"></label></td>
 			</tr>
 			</tbody>
 			</table>


### PR DESCRIPTION
Google Sheet Config settings
Added google sheets master settings panel functionality. I found it time consuming to update the settings for all of my toons, especially when some of them are rotating through the same browser using the hypervisor, so I added functionality for managing configurations with a publicly URL-accessable google sheet. Here's an example of one here: https://docs.google.com/spreadsheets/d/18Z14iWOp1GokZInKXjO_c1L-WH1EGR-ePKyv7z2HK3o/edit?usp=sharing

The configuration of this is done through the Chrome extensions Castle Age options button. There you can enter the google sheet ID. '18Z14iWOp1GokZInKXjO_c1L-WH1EGR-ePKyv7z2HK3o' for the above example. You'll need to make your own. Also, you can enter any string including double-byte characters to use as a salt for the hash to identify your toons. I thought it would be bad to have a publicly accessible list of the FB IDs of all of my toons, so I've hashed and salted them. After you enter the salt string into the options, you can see the salted has for your toons come up in the logs, like this:
gsheet: Loading google data sheet ID 18Z14iWOp1GokZInKXjO_c1L-WH1EGR-ePKyv7z2HK3o with hash 5982f989cb856661846febdeb458a7

Enter the hash 5982f989cb856661846febdeb458a7 into your spreadsheet under the mds column and put whatever config variables you want to enter into the top row, and CAAP will set those variables when it loads.

Guild Battlea
Previously, attack or heal moves would be largely based on the win chance or level of the target. This could cause some moves that weren't strategic, like doing a whirlwind on a low healtah target with stunned neighbors when there were three full health targets lined up lower on the tower. I've rewritten all of the attack routines to estimate the amount of damage your attack will do, both against the direct target and secondary and tertiary targets in the case of whirlwind, fireball, and mass heal. This damage estimate is then multiplied against your estimated chance to beat that opponent, and then scaled to a number from 0 - 100. This gives a smarter target selection, and a lot of old modifiers, such as poison, guardian, stunned, healed, etc. are no longer necessary for attacks. You don't need to tell CAAP any more that whirlwind is a better attack than duel. It already knows. :D

The battle damage estimate is based off the formulas on this page,  https://docs.google.com/spreadsheets/d/1qFnyxCNBULkUjkJns_k77AUasKkM4Am5QG8H8dK_6Xw/edit#gid=0 plus some tests to confirm how fireball and mass heal etc. work. They take into account your damage rune, any class specific generals you use, rune generals like Deianira, target poison or guardian status, class bonuses like rogue damage, tower splash or heal damage for mages or clerics respectively, and are rationalised to a per token benefit, i.e. fireball may do more damage, but not on a per token basis against a full tower. Not accounted for yet are Meekah, shout, and confidence.

I rewrote the loadout selection code, as well, to be more flexible and smarter about selecting loadouts. CAAP will do a scan of all your loadouts every 5 hours to see which loadout has which powers. Then, when doing that attack, if no loadout is specified or the specified loadout doesn't actually have that attack, it will use the first loadout that does have that power. 

Other GB Stuff
Fix for floating point health numbers. "2134.5/30000"
Change to look for locked picture in towers instead of manual keep logic, to be more accurate for different levels of keeps.
Swap added as a power, although not easy to use yet.
Fix for using the wrong traits (guardian, poison, etc.) for targets
Fix for 10v10, 100v100, and classic modifiers. It was using the internal names by mistake.
Tune seal start definition from 1000 damage to 5000 damage
Change class general loadout time to 15 min to 5 min before the 100v100 and 10v10 battles.

Monster
Fix for 3X or 5X power attacks firing without enough stamina

Generals
Move from general.getCurrent() and general.getLoadout() functions to general.current and general.loadout variables, to reduce CPU load by reducing Jquery DOM calls 

Stats
Add stats.runes values for the four runes
Reduce the four essence Jquery DOM checks to one regex check to get all four values to reduce CPU load

Worker
Fix the deletion of items not in template