### PR TITLE
Quest Loop Fix

### DIFF
--- a/Chrome/unpacked/js/caap_mainloop.js
+++ b/Chrome/unpacked/js/caap_mainloop.js
@@ -420,7 +420,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             if (force || (!config.getItem('Disabled') && state.getItem('caapPause') === 'none')) {
                 // better than reload... no prompt on forms!
                 con.log(1, 'Reloading now!');
-				if (typeof hyper != 'undefined' && $u.isArray(hyper.getItem('logons',false)) && hyper.getItem('logons',false).length > 1) {
+				if (!caap.checkForImage('web3splash.jpg').length && typeof hyper != 'undefined' && $u.isArray(hyper.getItem('logons',false)) && hyper.getItem('logons',false).length > 1) {
 					suffix = '/connect_login.php?platform_action=CA_web3_logout';
 				} else if (caap.domain.which === 0 || caap.domain.which === 2) {
 					suffix = '/keep.php';

--- a/Chrome/unpacked/js/worker_general.js
+++ b/Chrome/unpacked/js/worker_general.js
@@ -102,6 +102,10 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 				worker.addPageCheck({page : 'ajax:player_loadouts.php?loadout=' + v, hours : 5});
 			});
 			
+			['SubQuest', 'Monster', 'Buy', 'Idle', 'Collect'].forEach( function(g) {
+				config.deleteItem(g + 'LevelUpGeneral');
+			});
+				
 			return true;
 		} catch (err) {
 			con.error("ERROR in general.init: " + err.stack);
@@ -729,7 +733,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
                 state.setItem('KeepLevelUpGeneral', false);
             }
 
-            if (config.getItem('LevelUpGeneral', 'Use Current') !== 'Use Current' && (general.menuList.hasIndexOf(generalType) || generalType === 'Quest')) {
+            if (config.getItem('Level_UpGeneral', 'Use Current') !== 'Use Current' && (general.menuList.hasIndexOf(generalType) || generalType === 'Quest')) {
                 if (keepGeneral || (config.getItem(generalType + 'LevelUpGeneral', false) && stats.exp.dif && stats.exp.dif <= config.getItem('LevelUpGeneralExp', 0))) {
                     use = true;
                 }
@@ -803,7 +807,7 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
 
             con.log(3, 'Cool', coolType, coolName);
             if (levelUp) {
-                whichGeneral = 'LevelUpGeneral';
+                whichGeneral = 'Level_UpGeneral';
                 con.log(2, 'Using level up general');
             }
 
@@ -1011,17 +1015,11 @@ schedule,gifting,state,army,general,session,monster,worker,guild_monster */
             });
             htmlCode += caap.display.start('Level_UpGeneral', 'isnot', 'Use Current');
             htmlCode += caap.makeNumberFormTR("Exp To Use Gen", 'LevelUpGeneralExp', LevelUpGenExpInstructions, 55, '', '', true, false);
-            htmlCode += caap.makeCheckTR("Gen For Idle", 'IdleLevelUpGeneral', true, LevelUpGenInstructions1, true, false);
-            htmlCode += caap.makeCheckTR("Gen For Monsters", 'MonsterLevelUpGeneral', true, LevelUpGenInstructions2, true, false);
             htmlCode += caap.makeCheckTR("Gen For Guild Monsters", 'GuildMonsterLevelUpGeneral', true, LevelUpGenInstructions12, true, false);
             htmlCode += caap.makeCheckTR("Gen For Fortify", 'FortifyLevelUpGeneral', true, LevelUpGenInstructions3, true, false);
             htmlCode += caap.makeCheckTR("Gen For Invades", 'InvadeLevelUpGeneral', true, LevelUpGenInstructions4, true, false);
             htmlCode += caap.makeCheckTR("Gen For Duels", 'DuelLevelUpGeneral', true, LevelUpGenInstructions5, true, false);
             htmlCode += caap.makeCheckTR("Gen For Wars", 'WarLevelUpGeneral', true, LevelUpGenInstructions6, true, false);
-            htmlCode += caap.makeCheckTR("Gen For SubQuests", 'SubQuestLevelUpGeneral', true, LevelUpGenInstructions7, true, false);
-            htmlCode += caap.makeCheckTR("Gen For Buy", 'BuyLevelUpGeneral', true, LevelUpGenInstructions14, true, false);
-            htmlCode += caap.makeCheckTR("Gen For Collect", 'CollectLevelUpGeneral', true, LevelUpGenInstructions15, true, false);
-            htmlCode += caap.makeCheckTR("Gen For MainQuests", 'QuestLevelUpGeneral', false, LevelUpGenInstructions8, true, false);
             htmlCode += caap.makeCheckTR("Do not Bank After", 'NoBankAfterLvl', true, LevelUpGenInstructions9, true, false);
             htmlCode += caap.makeCheckTR("Do not Income After", 'NoIncomeAfterLvl', true, LevelUpGenInstructions10, true, false);
             htmlCode += caap.makeCheckTR("Prioritise Monster After", 'PrioritiseMonsterAfterLvl', false, LevelUpGenInstructions11, true, false);

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -344,7 +344,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					row,
 					head,
 					body,
-					text = $j('#app_body').text().trim().innerTrim().replace('COMING SOON This feature is coming soon! ', '').replace(/(You have \d+ Upgrade Points to use\! Click the ' ' buttons below to upgrade your stats\! )/, '');
+					text = $j('#app_body').text().trim().innerTrim().replace('COMING SOON This feature is coming soon! ', '').replace(/(You have \d+ Upgrade Points to use\! Click the ' ' buttons below to upgrade your stats\! )/, '').replace(caap.resultsText + ' ', '');
 
 				if (!text.match(/Army Size - Take more soldiers into battle!/)) {
 					tempDiv = $j("#app_body a[href*='keep.php?user=']");


### PR DESCRIPTION
Quests
Fix quest loop from general swap
Improve quest level up calc -- will now equip level up general only when
quest will put you to the next level

Generals
Remove config menu checkbox options for areas that do not give
experience or where the worker already handles the level up calc, like
monster or quest.

Other
Add splash screen detection to prevent CAAP from freezing on logon page