### PR TITLE
Festival Duels, Battle Rewrite, General Reset Build

### DIFF
--- a/Chrome/unpacked/js/caap_mainloop.js
+++ b/Chrome/unpacked/js/caap_mainloop.js
@@ -231,6 +231,13 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
+	caap.passThrough = function(result)  {
+		if (result && (!$u.isObject(result) || $u.setContent(result.action, true))) {
+			return result;
+		}
+		return false;
+	};
+	
     caap.mainLoop = function () {
         try {
             var button = $j(),
@@ -367,7 +374,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 						con.warn(ucName + ': ' + warnText);
 					}
 				}
-                if (!$u.isObject(returnObj) ? returnObj : $u.setContent(returnObj.action, true)) {
+                if (caap.passThrough(returnObj)) {
                     caap.checkLastAction(action);
 					return true;
                 }
@@ -425,7 +432,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             if (force || (!config.getItem('Disabled') && state.getItem('caapPause') === 'none')) {
                 // better than reload... no prompt on forms!
                 con.log(1, 'Reloading now!');
-				if (!caap.checkForImage('web3splash.jpg').length && typeof hyper != 'undefined' && $u.isArray(hyper.getItem('logons',false)) && hyper.getItem('logons',false).length > 1) {
+				if (caap.checkForImage('header_persist_background.jpg').length && typeof hyper != 'undefined' && $u.isArray(hyper.getItem('logons',false)) && hyper.getItem('logons',false).length > 1) {
 					suffix = '/connect_login.php?platform_action=CA_web3_logout';
 				} else if (caap.domain.which === 0 || caap.domain.which === 2) {
 					suffix = '/keep.php';
@@ -451,10 +458,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			if (state.getItem('caapPause', 'none') == 'none') {
 				if (schedule.since("clickedOnSomething", 300) || session.getItem("pageLoadCounter", 0) > 40
 						|| (caap.hyper && schedule.since("hyperTimer", reloadMin * 60))) {
-					con.log(1, 'Reloading if not paused after inactivity');
+					con.log(1, 'Reloading after inactivity');
 					session.setItem("flagReload", true);
-				} else {
-					con.log(2, 'Checked for reload, but not necessary', schedule.since("clickedOnSomething", 300), session.getItem("pageLoadCounter", 0) > 40, caap.hyper, schedule.since("hyperTimer", reloadMin * 60));
 				}
 			}
             window.setTimeout(function () {

--- a/Chrome/unpacked/js/caap_navigation.js
+++ b/Chrome/unpacked/js/caap_navigation.js
@@ -422,6 +422,8 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 	// Returns true if first page navigation complete, 'done' if clicked the link, and false if on page but link not there
     caap.navigate3 = function (toPage, click, thisGeneral, options) {
         try {
+			var clickUrl = session.getItem('clickUrl', '');
+			
 			if (caap.bad3.hasIndexOf(toPage + ':' + click)) {
 				return false;
 			}
@@ -431,9 +433,9 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 			}
 			
 			options = $u.setContent(options, {});
-			if (!session.getItem('clickUrl', '').hasIndexOf(toPage)) {
+			if (caap.page != toPage.replace(/\.php.*/, '') || !clickUrl.hasIndexOf(toPage)) {
 				caap.ajaxLink(toPage);
-				con.log(2, 'Navigate3: Go to ajax link '+ toPage);
+				con.log(2, 'Navigate3: Go to ajax link '+ toPage, caap.page, clickUrl);
 				return true;
 			}
 			
@@ -447,11 +449,13 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 				return $j(this).serialize();
 			})).filter( function(l) {
 				// If any of the names are not found in a form, that link not valid
-				return !click.regex(/(\w+=)\w+/g).some( function(r) {
-					return !l.hasIndexOf(r);
+				return !click.regex(/(\w+)=\w+/g).some( function(r) {
+					return !l.match(new RegExp('\\b' + r + '\\b='));
 				});
 			});
 			if (links.length) {
+				click += links[0].regexd(/(&bqh=\w+)/, '');
+				click += links[0].regexd(/(&ajax=1)/, '');
 				caap.ajaxLink(click);
 				con.log(2, 'Navigate3: Clicking form link '+ click);
 				return 'done';

--- a/Chrome/unpacked/js/worker.js
+++ b/Chrome/unpacked/js/worker.js
@@ -99,7 +99,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					});
 				});
 				undefinedKeyList.removeFromList('newRecord');
-				if (undefinedKeyList.length) {
+				if (state.getItem('wsave_' + wO.name + '_noWarning')) {
+					state.deleteItem('wsave_' + wO.name + '_noWarning');
+				} else if (undefinedKeyList.length) {
 					con.warn(wO.name + ' warning: Keys not in record template will be deleted: ' + undefinedKeyList.join(', '), o);
 				}
 				if (caap.domain.which === 3) {

--- a/Chrome/unpacked/js/worker_chores.js
+++ b/Chrome/unpacked/js/worker_chores.js
@@ -14,7 +14,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 	chores.checkResults = function(page, resultsText) {
 		try {
 			var pagesHeaders = worker.pagesList.flatten('page'),
-				url = 'ajax:' + session.getItem('clickUrl', 'none'),
+				url = 'ajax:' + caap.clickUrl,
 				picList = [],
 				dupList = [],
 				nameList = [],
@@ -52,6 +52,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				con.log(2, 'Alchemy ingredients in multiple recipes list: ' + nameList.join(', '), dupList);
 				break;
 			case 'goblin_emp' :
+				if (config.getItem("goblinHinting", true)) {
+					spreadsheet.doTitles(true);
+				}
 				if (/You have exceeded the 10 emporium roll limit for the day/.test(resultsText)) {
 					schedule.setItem('koboTimerDelay', 7 * 3600, 100);
 					con.log(2, 'Kobo: hit maximum rolls');
@@ -480,14 +483,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
  	worker.addAction({fName : 'chores.checkPages', priority : -1200, description : 'Reviewing Pages'});
 	
-	worker.addPageCheck({page : 'oracle'});
-
-	worker.addPageCheck({page : 'battlerank', path : 'battle,battlerank', level : 8});
-
-	worker.addPageCheck({page : 'war_rank', path : 'battle,war_rank', level : 100});
-
-	worker.addPageCheck({page : 'conquest_battlerank', level : 80});
-
 	worker.addPageCheck({page : 'conquest_duel'});
 
 	worker.addPageCheck({page : 'achievements'});
@@ -504,7 +499,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				: $u.isString(page) ? [{page : page}] : worker.pagesList,
 				hours = 0;
 			return list.some( function(o) {
-				if (o.config && !config.getItem(o.config, false)) {
+				if ((o.config && !config.getItem(o.config, false)) ||
+						(o.func && !window[o.func.regex(/(\w+)\./)][o.func.regex(/\.(\w+)/)]())) {
 					return false;
 				}
 				hours = o.cFreq ? config.getItem(o.cFreq, 60) / 60 : $u.setContent(o.hours, 24);

--- a/Chrome/unpacked/js/worker_conquest.js
+++ b/Chrome/unpacked/js/worker_conquest.js
@@ -13,12 +13,45 @@ schedule,state,general,session */
 (function() {
     "use strict";
 
-	worker.add('conquest');
+	worker.add({name: 'conquest', recordIndex: 'userId'});
 	
-    conquest.targetsOnPage = [];
+    conquest.record = function(userId) {
+        this.data = {
+            userId: userId,
+            name: '',
+            conqRank: -1,
+            //arenaRank: -1,
+            level: 0,
+            army: 0
+        };
+    };
+	
+	conquest.init = function() {
+		try {
 
-    conquest.targets = [];
-
+			// Keep best 250 targets
+			if (conquest.records.length > 250) {
+				var which = 'Conq' + config.getItem('ConquestType', 'Invade');
+				
+				conquest.records.forEach( function(r) {
+					r.score = battle.scoring(r, which);
+				});
+				
+				conquest.records.sort($u.sortBy(true, 'score'));
+				
+				con.log(2, 'Conquest: Kept 250 recon targets and removed ' + (conquest.records.length - 250) + ' lesser targets');
+				conquest.records = conquest.records.slice(0, 249);
+				state.setItem('conqScore', conquest.records[249].score);
+				state.setItem('wsave_conquest', true);
+				state.setItem('wsave_conquest_noWarning', true);
+			}
+			
+        } catch (err) {
+            con.error("ERROR in conquest.init: " + err.stack);
+            return false;
+        }
+    };
+	
 	conquest.checkResults = function(page, resultsText) {
         try {
             var tempDiv, text;
@@ -26,7 +59,6 @@ schedule,state,general,session */
 			switch (page) {
 			case 'conquest_duel' :
 				// Check coins
-				conquest.battle(page, resultsText);
 				tempDiv = $j("#guild_token_current_value");
 				if ($u.hasContent(tempDiv)) {
 					stats.guildTokens = caap.getStatusNumbers(tempDiv.eq(0).parent().text().trim());
@@ -83,95 +115,26 @@ schedule,state,general,session */
         }
 	};
 
-    conquest.conquestUserId = function(record) {
-        try {
-            var conquestButton = $j(),
-                form = $j(),
-                inp = $j();
-
-            conquestButton = caap.checkForImage(conquest.battles[config.getItem('ConquestType', 'Invade')]);
-            if ($u.hasContent(conquestButton)) {
-                form = conquestButton.parent().parent();
-                if ($u.hasContent(form)) {
-                    inp = $j("input[name='target_id']", form);
-                    if ($u.hasContent(inp)) {
-                        inp.attr("value", record.userId);
-                        con.log(1, 'Attacking', record);
-						battle.setRecord(record);
-                        conquest.click(conquestButton, record.userId);
-                        conquestButton = null;
-                        form = null;
-                        inp = null;
-                        return true;
-                    }
-
-                    con.warn("target_id not found in conquestForm");
-                } else {
-                    con.warn("form not found in conquestButton");
-                }
-            } else {
-                con.warn("conquestButton not found");
-            }
-
-            conquestButton = null;
-            form = null;
-            inp = null;
-            return false;
-        } catch (err) {
-            con.error("ERROR in conquestUserId: " + err.stack);
-            return false;
-        }
-    };
-
-    conquest.conquestWarnLevel = true;
-
-	worker.addAction({worker : 'conquest', priority : 500, description : 'Conquesting Players'});
+	worker.addAction({worker : 'conquest', priority : 500, description : 'Using Conquest Coins'});
 	
     conquest.worker = function() {
         try {
-            var whenconquest = '',
-                bR = {},
-                targetId = 0,
-				result,
-                conquesttype = '',
-                useGeneral = '',
-                chainImg = '',
-	            tempDiv = $j(),
-                button = $j(),
-                conquestChainId = 0,
-                it = 0,
-                len = 0;
+            var whenconquest = config.getItem('WhenConquest', 'Never'),
+                conquesttype = config.getItem('ConquestType', 'Invade'),
+				result;
 
-            whenconquest = config.getItem('WhenConquest', 'Never');
             if (whenconquest === 'Never') {
-                caap.setDivContent('conquest_mess', 'Conquest off');
-                return false;
+                return {action: false, mess: ''};
             }
 
-			if (stats.guildTokens.num > stats.guildTokens.max) {
-                con.log(1, 'Checking max conquest coins', $u.setContent(caap.displayTime('conquest_token'), "Unknown"), stats.guildTokens.num, stats.guildTokens.max);
-                caap.setDivContent('conquest_mess', 'Checking coins');
-                if (caap.navigateTo('conquest_duel')) {
-                    return true;
-                }
-            }
+			if (stats.guildTokens.num > stats.guildTokens.max && caap.navigateTo('conquest_duel')) {
+				return {mlog: 'Checking coins'};
+			}
 
-			if (!schedule.check("conquest_delay")) {
-                con.log(4, 'Conquest delay attack', $u.setContent(caap.displayTime('conquest_delay'), "Unknown"));
-                caap.setDivContent('conquest_mess', 'Conquest delay (' + $u.setContent(caap.displayTime('conquest_delay'), "Unknown") + ')');
-                return false;
-            }
+            /*-------------------------------------------------------------------------------------\
+			LoE and LoM checks
+			\-------------------------------------------------------------------------------------*/
 
-            if (stats.level >= 8 && stats.health.num >= 10 && stats.stamina < 0) {
-                schedule.setItem("conquest_delay_stats", 0);
-            }
-
-            if (!schedule.check("conquest_delay_stats")) {
-                con.log(4, 'Conquest delay stats', $u.setContent(caap.displayTime('conquest_delay_stats'), "Unknown"));
-                caap.setDivContent('conquest_mess', 'Conquest stats (' + $u.setContent(caap.displayTime('conquest_delay_stats'), "Unknown") + ')');
-                return false;
-            }
-			
 			result = loe.worker('your', 'loe');
 			if (result && (!$u.isObject(result) || $u.setContent(result.action, true))) {
 				return result;
@@ -196,841 +159,46 @@ schedule,state,general,session */
 				}
 			}
 
-			if (whenconquest === 'At Max Coins' && stats.guildTokens.max >= 10 && stats.guildTokens.num !== stats.guildTokens.max) {
-				con.log(4, 'Waiting for Max coins ' + stats.guildTokens.num + '/' + stats.guildTokens.max);
-				caap.setDivContent('conquest_mess', 'Waiting Max coins ' + stats.guildTokens.num + '/' + stats.guildTokens.max + ' (' + $u.setContent(caap.displayTime('conquest_token'), "Unknown") + ')');
-				state.setItem("ConquestChainId", 0);
-				return false;
+			if (stats.guildTokens.num < stats.conquest.dif || stats.guildTokens.num == 0){ // Burn tokens if able to level up
+				switch (whenconquest) {
+				case 'At Max Coins' :
+					if (stats.guildTokens.max >= 10 && stats.guildTokens.num !== stats.guildTokens.max) {
+						return {action: false, mess: 'Waiting Max coins ' + stats.guildTokens.num + '/' + stats.guildTokens.max};
+					}
+					break;
+				case 'At X Coins' :
+					if (stats.guildTokens.num >= config.getItem('ConquestXCoins', 1)) {
+						state.setItem('conquest_burn', true);
+					} else if (stats.guildTokens.num <= config.getItem('ConquestXMinCoins', 0)) {
+						state.setItem('conquest_burn', false);
+						return {action: false, mess: 'Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins', 1)};
+					}
+					if (stats.guildTokens.num < config.getItem('ConquestXCoins', 1) && !state.getItem('conquest_burn', false)) {
+						state.setItem('conquest_burn', false);
+						return {action: false, mess: 'Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins', 1)};
+					}
+					break;
+				case 'Coins Available' :
+					if (stats.guildTokens.num === 0) {
+						return {action: false, mess: 'Waiting for Coins ' + stats.guildTokens.num + '/1'};
+					}
+					break;
+				}
 			}
 
-			if (whenconquest === 'At X Coins' && stats.guildTokens.num >= config.getItem('ConquestXCoins', 1)) {
-				state.setItem('conquest_burn', true);
-				con.log(1, 'Burn tokens ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins'));
-			}
-
-			con.log(4, 'Waiting X coins burn', state.getItem('conquest_burn', false));
-			if (whenconquest === 'At X Coins' && stats.guildTokens.num <= config.getItem('ConquestXMinCoins', 0)) {
-				state.setItem('conquest_burn', false);
-				con.log(4, '1:Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins'));
-				caap.setDivContent('conquest_mess', 'Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins', 1) + ' (' + $u.setContent(caap.displayTime('conquest_token'), "Unknown") + ')');
-				state.setItem("ConquestChainId", 0);
-				button = null;
-				return false;
-			}
-
-			if (whenconquest === 'At X Coins' && stats.guildTokens.num < config.getItem('ConquestXCoins', 1) && !state.getItem('conquest_burn', false)) {
-				state.setItem('conquest_burn', false);
-				con.log(4, '2:Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins'));
-				caap.setDivContent('conquest_mess', 'Waiting X coins ' + stats.guildTokens.num + '/' + config.getItem('ConquestXCoins', 1) + ' (' + $u.setContent(caap.displayTime('conquest_token'), "Unknown") + ')');
-				state.setItem("ConquestChainId", 0);
-				button = null;
-				return false;
-			}
-
-			if (whenconquest === 'Coins Available' && stats.guildTokens.num < 1) {
-				con.log(4, 'Waiting Coins Available ' + stats.guildTokens.num + '/1');
-				caap.setDivContent('conquest_mess', 'Coins Available ' + stats.guildTokens.num + '/1 (' + $u.setContent(caap.displayTime('conquest_token'), "Unknown") + ')');
-				state.setItem("ConquestChainId", 0);
-				button = null;
-				return false;
-			}
-
-			caap.setDivContent('conquest_mess', 'Conquest Ready');
-
-            if (stats.level < 8) {
-                schedule.setItem("conquest_token", 86400, 300);
-                schedule.setItem("conquest_delay_stats", 86400, 300);
-                if (conquest.conquestWarnLevel) {
-                    con.log(1, "conquest: Unlock at level 8");
-                    conquest.conquestWarnLevel = false;
-                }
-
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return false;
-            }
-
-            conquesttype = config.getItem('ConquestType', 'Invade');
+			// Check health ok
             if (!caap.checkStamina('Conquest', 1)) {
-                con.log(1, 'Not enough stamina for ', conquesttype);
-                schedule.setItem("conquest_delay_stats", (stats.stamina.ticker[0] * 60) + stats.stamina.ticker[1], 300);
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return false;
+                return {action: false, mess: 'Not enough health for ' + conquesttype};
             }
+			
+			return battle.common('Conq' + conquesttype, 'Freshmeat');
 
-            switch (conquesttype) {
-            case 'Invade':
-                useGeneral = 'InvadeGeneral';
-                chainImg = conquest.battles.InvadeChain;
-                if (general.LevelUpCheck(useGeneral)) {
-                    useGeneral = 'LevelUpGeneral';
-                    con.log(1, 'Using level up general');
-                }
-
-                break;
-            case 'Duel':
-                useGeneral = 'DuelGeneral';
-                chainImg = conquest.battles.DuelChain;
-                if (general.LevelUpCheck(useGeneral)) {
-                    useGeneral = 'LevelUpGeneral';
-                    con.log(1, 'Using level up general');
-                }
-
-                break;
-            default:
-                con.warn('Unknown conquest type ', conquesttype);
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return false;
-            }
-
-            con.log(1, conquesttype, useGeneral);
-            if (general.Select(useGeneral)) {
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return true;
-            }
-
-            if (caap.navigateTo('conquest_duel', 'conqduel_on.jpg')) {
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return true;
-            }
-
-            con.log(1, 'Chain target');
-            // Check if we should chain attack
-            tempDiv = $j("#app_body div[style*='war_fort_battlevictory.jpg']");
-            con.log(1, 'Chain target victory check', tempDiv);
-            if ($u.hasContent(tempDiv)) {
-                con.log(1, 'Chain target victory!');
-                button = $j("#app_body input[src*='" + chainImg + "']");
-                con.log(1, 'Chain target button check', button);
-                conquestChainId = state.getItem("ConquestChainId", 0);
-                con.log(1, 'Chain target conquestChainId', conquestChainId);
-                if ($u.hasContent(button) && $u.isNumber(conquestChainId) && conquestChainId > 0) {
-                    caap.setDivContent('conquest_mess', 'Chain Attack In Progress');
-                    con.log(1, 'Chaining Target', conquestChainId);
-                    conquest.click(button, conquestChainId);
-                    state.setItem("ConquestChainId", 0);
-                    button = null;
-                    return true;
-                }
-
-                state.setItem("ConquestChainId", 0);
-            }
-
-            con.log(1, 'Get on page target');
-            targetId = $u.hasContent(conquest.targets) ? conquest.targets[0] : 0;
-            con.log(1, 'targetId', targetId);
-            if (!$u.hasContent(targetId) || targetId < 1) {
-                con.log(1, 'No valid conquest targetId', targetId);
-                schedule.setItem('conquest_delay', Math.floor(Math.random() * 240) + 60);
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return false;
-            }
-
-            for (it = 0, len = conquest.targetsOnPage.length; it < len; it += 1) {
-                if (conquest.targetsOnPage[it].userId === targetId) {
-                    bR = conquest.targetsOnPage[it];
-                }
-            }
-
-            if (!$u.hasContent(bR)) {
-                con.log(1, 'No valid conquest target',targetId, bR, conquest.targets);
-                state.setItem("ConquestChainId", 0);
-                button = null;
-                return false;
-            }
-
-            con.log(1, 'conquest Target', bR);
-            if (conquest.conquestUserId(bR)) {
-                caap.setDivContent('conquest_mess', 'Conquest Target: ' + bR.userId);
-                button = null;
-                return true;
-            }
-
-            con.warn('Doing conquest target list, but no target');
-            state.setItem("ConquestChainId", 0);
-            button = null;
-            return false;
         } catch (err) {
-            con.error("ERROR in conquest: " + err.stack);
+            con.error("ERROR in conquest.worker: " + err.stack);
             return false;
         }
     };
 	
-    conquest.conquestRankTier = function(points) {
-        var tier = 0;
-
-        if (points >= 50000) {
-            tier = 18;
-        } else if (points >= 43000) {
-            tier = 17;
-        } else if (points >= 37000) {
-            tier = 16;
-        } else if (points >= 32500) {
-            tier = 15;
-        } else if (points >= 27000) {
-            tier = 14;
-        } else if (points >= 22500) {
-            tier = 13;
-        } else if (points >= 19500) {
-            tier = 12;
-        } else if (points >= 14000) {
-            tier = 11;
-        } else if (points >= 10000) {
-            tier = 10;
-        } else if (points >= 7500) {
-            tier = 9;
-        } else if (points >= 5000) {
-            tier = 8;
-        } else if (points >= 3000) {
-            tier = 7;
-        } else if (points >= 2000) {
-            tier = 6;
-        } else if (points >= 1200) {
-            tier = 5;
-        } else if (points >= 700) {
-            tier = 4;
-        } else if (points >= 450) {
-            tier = 3;
-        } else if (points >= 250) {
-            tier = 2;
-        } else if (points >= 100) {
-            tier = 1;
-        }
-
-        return tier;
-    };
-
-    conquest.conquestRankTable = {
-        0: 'Grunt',
-        1: 'Scout',
-        2: 'Soldier',
-        3: 'Elite Soldier',
-        4: 'Squire',
-        5: 'Night',
-        6: 'First Night',
-        7: 'Legionnaire',
-        8: 'Centurian',
-        9: 'Champion',
-        10: 'Lt Commander',
-        11: 'Commander',
-        12: 'High Commander',
-        13: 'Lieutenant General',
-        14: 'General',
-        15: 'High General',
-        16: 'Baron',
-        17: 'Earl',
-        18: 'Duke'
-    };
-
-    conquest.click = function(conquestButton, userId) {
-        try {
-            conquest.flagResult = true;
-			state.setItem('lastBattleID', userId);
-            caap.setDomWaiting("conquest_duel.php");
-            caap.click(conquestButton);
-            return true;
-        } catch (err) {
-            con.error("ERROR in conquest.click: " + err.stack);
-            return false;
-        }
-    };
-
-    conquest.battles = {
-        'Invade': 'war_conquest_invadebtn.gif',
-        'Duel': 'war_conquest_duelbtn.gif',
-        'InvadeChain': 'war_invadeagainbtn.gif',
-        'DuelChain': 'war_duelagainbtn.gif'
-    };
-
-    conquest.getCommonInfos = function(slice) {
-        try {
-            var levelDiv = $j(),
-                percentageDiv = $j(),
-                rechargeDiv = $j(),
-                rechargeSecs = 0,
-                timeDiv = $j(),
-                timeSecs = 0,
-                tokensDiv = $j(),
-                tempText = '',
-                passedStats = true;
-
-            if (!$u.hasContent(slice)) {
-                con.warn("No slice passed to conquest.getCommonInfos");
-                levelDiv = null;
-                percentageDiv = null;
-                rechargeDiv = null;
-                timeDiv = null;
-                tokensDiv = null;
-                return;
-            }
-
-            if (caap.hasImage('guild_tab6_on.jpg')) {
-                tempText = slice.text();
-                if ($u.hasContent(tempText)) {
-                    stats.resources.lumber = $u.setContent(tempText.regex(/^\s+(\d+)\s+\d+/i), 0);
-                    stats.resources.iron = $u.setContent(tempText.regex(/^\s+\d+\s+(\d+)/i), 0);
-                    stats.guild.level = $u.setContent(tempText.regex(/\s+GUILD LEVEL:\s+(\d+)/i), 0);
-                    stats.rank.conquestLevel = $u.setContent(tempText.regex(/\s+CONQUEST LV:\s+(\d+)/i), 0);
-                } else {
-                    con.warn("Unable to get slice text", slice);
-                    passedStats = false;
-                }
-            } else if (caap.hasImage('conqduel_on.jpg')) {
-                levelDiv = $j("div[style*='width:160px;height:12px;color:#80cfec']", slice);
-                if ($u.hasContent(levelDiv)) {
-                    stats.rank.conquestLevel = $u.setContent(levelDiv.text(), '').regex(/(\d+)/);
-                } else {
-                    con.warn("Unable to get conquest levelDiv");
-                    levelDiv = null;
-                    percentageDiv = null;
-                    rechargeDiv = null;
-                    timeDiv = null;
-                    tokensDiv = null;
-                    return;
-                }
-            } else {
-                con.warn("Unable to get infos from this page");
-                passedStats = false;
-            }
-
-            percentageDiv = $j("div[style*='war_redbar.jpg']", slice);
-            if ($u.hasContent(percentageDiv && percentageDiv.length === 2)) {
-                stats.guild.levelPercent = $u.setContent(percentageDiv.getPercent('width'), 0);
-            } else if ($u.hasContent(percentageDiv) && percentageDiv.length === 1) {
-                stats.rank.conquestLevelPercent = $u.setContent(percentageDiv.getPercent('width'), 0);
-            } else {
-                con.warn("Unable to get conquest percentageDiv");
-                passedStats = false;
-            }
-
-            tokensDiv = $j("#guild_token_current_value", slice).parent();
-            if ($u.hasContent(tokensDiv)) {
-                tempText = $u.setContent(tokensDiv.text(), '').stripTRN();
-                if ($u.hasContent(tempText)) {
-                    stats.guildTokens.num = $u.setContent(tempText.regex(/(\d+)\/\d+/), 0);
-                    stats.guildTokens.max = $u.setContent(tempText.regex(/\d+\/(\d+)/), 0);
-                } else {
-                    con.warn("Unable to get tokensDiv text", tokensDiv);
-                    passedStats = false;
-                }
-            } else {
-                tokensDiv = $j("#guild_token_current_value_amount", slice);
-                if ($u.hasContent(tokensDiv)) {
-                    tempText = $u.setContent(tokensDiv.val(), '');
-                    if ($u.hasContent(tempText)) {
-                        stats.guildTokens.num = $u.setContent(tempText.regex(/(\d+)/), 0);
-                    } else {
-                        con.warn("Unable to get guild_token_current_value_amount text", tokensDiv);
-                        passedStats = false;
-                    }
-                } else {
-                    con.warn("Unable to get conquest tokensMaxDiv");
-                    passedStats = false;
-                }
-
-                tokensDiv = $j("#guild_token_current_max", slice);
-                if ($u.hasContent(tokensDiv)) {
-                    tempText = $u.setContent(tokensDiv.val(), '');
-                    if ($u.hasContent(tempText)) {
-                        stats.guildTokens.max = $u.setContent(tempText.regex(/(\d+)/), 0);
-                        if (stats.guildTokens.max < 10){
-                            con.warn("guild_token_current_max is too low", stats.guildTokens.max);
-                            passedStats = false;
-                        }
-                    } else {
-                        con.warn("Unable to get guild_token_current_max text", tokensDiv);
-                        passedStats = false;
-                    }
-                } else {
-                    con.warn("Unable to get conquest tokensMaxDiv");
-                    passedStats = false;
-                }
-            }
-
-            stats.guildTokens.dif = stats.guildTokens.max - stats.guildTokens.num;
-
-            con.log(1, "conquest.battle", stats.rank, stats.guildTokens);
-            if (passedStats) {
-                statsFunc.setRecord(stats);
-            }
-
-            if (passedStats && stats.guildTokens.max >= 10 && stats.guildTokens.num < stats.guildTokens.max) {
-                rechargeDiv = $j("#guild_token_current_recharge_time", slice);
-                if ($u.hasContent(rechargeDiv)) {
-                    rechargeSecs = $u.setContent(rechargeDiv.val(), '').regex(/(\d+)/);
-                } else {
-					con.warn("Unable to get conquest rechargeDiv");
-                }
-
-                timeDiv = $j("#guild_token_time_sec", slice);
-                if ($u.hasContent(timeDiv)) {
-                    timeSecs = $u.setContent(timeDiv.val(), '').regex(/(\d+)/);
-                    schedule.setItem("conquest_token", timeSecs, 300);
-                } else {
-					con.warn("Unable to get conquest timeDiv");
-                }
-            } else {
-                schedule.setItem("conquest_token", 300, 0);
-            }
-
-            con.log(1, "conquest.getCommonInfos", stats, rechargeSecs, timeSecs);
-
-            levelDiv = null;
-            percentageDiv = null;
-            rechargeDiv = null;
-            timeDiv = null;
-            tokensDiv = null;
-        } catch (err) {
-            con.error("ERROR in conquest.getCommonInfos: " + err.stack);
-        }
-    };
-
-    conquest.targeting = function() {
-        function logOpponent(opponent, reason, conditions) {
-            con.log(2, (reason === 'sorted' ? 1 : 2), (opponent.name.lpad(' ', 20) + opponent.userId.lpad(' ', 16) +
-                opponent.level.lpad(' ', 4) + conquest.conquestRankTable[opponent.conqRank].lpad(' ', 16) +
-                opponent.army.lpad(' ', 4) + opponent.score.dp().lpad(' ', 5)), reason, conditions);
-        }
-
-        try {
-            var opponentsSlice = $j("#app_body div[style*='war_conquest_mid']"),
-                minRank = 0,
-                maxRank = 0,
-                minLevel = 0,
-                maxLevel = 0,
-                ARBase = 0,
-                ARMin = 0,
-                ARMax = 0,
-                conquesttype = config.getItem('ConquestType', 'Invade'),
-                targets = [];
-
-            con.log(1, "conquest.targeting begins", stats);
-
-            conquest.targetsOnPage = [];
-            conquest.targets = [];
-
-            con.log(1, "in battle", opponentsSlice);
-            if (!$u.hasContent(opponentsSlice)) {
-                con.warn("missing opponentsSlice");
-                opponentsSlice = null;
-                return;
-            }
-
-            minLevel = config.getItem("ConquestMinLevel", 99999);
-            con.log(1, "ConquestMinLevel", minLevel);
-            if (minLevel === '' || $u.isNaN(minLevel)) {
-                if (minLevel !== '') {
-                    con.warn("ConquestMinLevel is NaN, using default", minLevel);
-                }
-
-                minLevel = 99999;
-            }
-
-            maxLevel = config.getItem("ConquestMaxLevel", 99999);
-            con.log(1, "ConquestMaxLevel", maxLevel);
-            if (maxLevel === '' || $u.isNaN(maxLevel)) {
-                if (maxLevel !== '') {
-                    con.warn("ConquestMaxLevel is NaN, using default", maxLevel);
-                }
-
-                maxLevel = 99999;
-            }
-
-            minRank = config.getItem("ConquestMinRank", 99);
-            con.log(1, "ConquestMinRank", minRank);
-            if (minRank === '' || $u.isNaN(minRank)) {
-                if (minRank !== '') {
-                    con.warn("ConquestMinRank is NaN, using default", 99);
-                }
-
-                minRank = 99;
-            }
-
-            maxRank = config.getItem("ConquestMaxRank", 99);
-            con.log(1, "ConquestMaxRank", maxRank);
-            if (maxRank === '' || $u.isNaN(maxRank)) {
-                if (maxRank !== '') {
-                    con.warn("ConquestMaxRank is NaN, using default", 99);
-                }
-
-                maxRank = 99;
-            }
-
-            ARBase = config.getItem("ConquestARBase", 0.7);
-            con.log(1, "ConquestARBase", ARBase);
-            if (ARBase === '' || $u.isNaN(ARBase)) {
-                if (ARBase !== '') {
-                    con.warn("ConquestARBase is NaN, using default", ARBase);
-                }
-
-                ARBase = 0.7;
-            }
-
-            ARMin = config.getItem("ConquestARMin", 0);
-            con.log(1, "ConquestARMin", ARMin);
-            if (ARMin === '' || $u.isNaN(ARMin)) {
-                if (ARMin !== '') {
-                    con.warn("ConquestARMin is NaN, using default", ARMin);
-                }
-
-                ARMin = 0;
-            }
-
-            ARMax = config.getItem("ConquestARMax", 99999);
-            con.log(1, "ConquestARMax", ARMax);
-            if (ARMax === '' || $u.isNaN(ARMax)) {
-                if (ARMax !== '') {
-                    con.warn("ConquestARMax is NaN, using default", ARMax);
-                }
-
-                ARMax = 99999;
-            }
-
-            con.log(1, "My rank/type is", conquest.conquestRankTable[stats.rank.conquest], stats.rank.conquest, conquesttype);
-
-            opponentsSlice.each(function() {
-                var opponentDiv = $j(this),
-                    boxesDiv = opponentDiv.children("div"),
-					idDiv = boxesDiv.eq(5),
-					playerDiv = boxesDiv.eq(2),
-					armyDiv = boxesDiv.eq(3),
-                    tempText = '',
-                    bR = {},
-                    levelMultiplier = 0,
-                    armyRatio = 0,
-                    tempTime = 0,
-					userId;
-
-                if (!$u.hasContent(boxesDiv) || boxesDiv.length !== 7 ) {
-                    con.warn("skipping opponent, missing boxes", opponentDiv);
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    return;
-                }
-
-                userId = parseInt($j("input[name='target_id']", idDiv)[0].defaultValue,10);
-                if (userId > 0) {
-                    bR = battle.getRecord(userId);
-                } else {
-                    con.warn("skipping opponent, unable to get userid", tempText);
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    idDiv = null;
-                    userId = null;
-                    return;
-                }
-
-                if ($u.hasContent(playerDiv)) {
-                    tempText = $u.setContent(playerDiv.text(), '');
-                    if ($u.hasContent(tempText)) {
-                        bR.name = $u.setContent(tempText.regex(/\s*(.+) \(Level/), '');
-                        bR.level = $u.setContent(tempText.regex(/Level (\d+)/i), -1);
-                        bR.conqRank = $u.setContent(tempText.regex(/Rank (\d+)/i), -1);
-
-                        if (bR.name === '') {
-                            con.warn("Unable to match opponent's name", tempText);
-                        }
-
-                        if (!$u.isNumber(bR.level) || !$u.isNumber(bR.conqRank) || bR.level === -1 || bR.conqRank === -1) {
-                            con.warn("skipping opponent, unable to get level or rank", tempText);
-                            opponentDiv = null;
-                            boxesDiv = null;
-                            idDiv = null;
-                            playerDiv = null;
-                            armyDiv = null;
-                            return;
-                        }
-                    } else {
-                        con.warn("No text in playerDiv");
-                        opponentDiv = null;
-                        boxesDiv = null;
-                        idDiv = null;
-                        playerDiv = null;
-                        armyDiv = null;
-                        return;
-                    }
-                } else {
-                    con.warn("skipping opponent, missing playerDiv", opponentDiv);
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                if ($u.hasContent(armyDiv)) {
-                    tempText = $u.setContent(armyDiv.text(), '');
-                    if ($u.hasContent(tempText)) {
-                        bR.army = $u.setContent(tempText.regex(/(\d+)/i), -1);
-
-                        if (bR.army=== -1) {
-                            con.warn("skipping opponent, unable to get army", tempText);
-                            opponentDiv = null;
-                            boxesDiv = null;
-                            idDiv = null;
-                            playerDiv = null;
-                            armyDiv = null;
-                            return;
-                        }
-                    } else {
-                        con.warn("No text in armyDiv");
-                        opponentDiv = null;
-                        boxesDiv = null;
-                        idDiv = null;
-                        playerDiv = null;
-                        armyDiv = null;
-                        return;
-                    }
-                } else {
-                    con.warn("skipping opponent, missing armyDiv", opponentDiv);
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-                levelMultiplier = stats.level / bR.level;
-                bR.score = bR.conqRank - (bR.army / levelMultiplier / stats.army.capped);
-                conquest.targetsOnPage.push(bR);
-                if (!$u.isNumber(stats.level) || (stats.level - minLevel > bR.level)) {
-                    logOpponent(bR, "minLevel", {
-                        'level': bR.level,
-                        'levelDif': stats.level - bR.level,
-                        'minLevel': minLevel
-                    });
-
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                if (!$u.isNumber(stats.level) || (stats.level + maxLevel <= bR.level)) {
-                    logOpponent(bR, "maxLevel", {
-                        opponent: bR,
-                        'level': bR.level,
-                        'levelDif': bR.level - stats.level,
-                        'maxLevel': maxLevel
-                    });
-
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                if (!$u.isNumber(stats.rank.conquest) || (stats.rank.conquest - minRank > bR.conqRank)) {
-                    logOpponent(bR, "minRank", {
-                        opponent: bR,
-                        'rankDif': stats.rank.conquest - bR.conqRank,
-                        'minRank': minRank
-                    });
-
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                if (!$u.isNumber(stats.rank.conquest) || (stats.rank.conquest + maxRank <= bR.conqRank)) {
-                    logOpponent(bR, "maxRank", {
-                        opponent: bR,
-                        'rankDif': bR.conqRank - stats.rank.conquest,
-                        'minRank': minRank
-                    });
-
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                levelMultiplier = $u.setContent(stats.level, 0) / $u.setContent(bR.level, 1);
-                armyRatio = ARBase * levelMultiplier;
-                armyRatio = Math.min(armyRatio, ARMax);
-                armyRatio = Math.max(armyRatio, ARMin);
-                if (armyRatio <= 0) {
-                    con.warn("Bad ratio", armyRatio, ARBase, ARMin, ARMax, levelMultiplier);
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                // if we know our army size, and this one is larger than armyRatio, don't conquest
-                if (conquesttype === 'Invade' && stats.army.capped && (bR.army > (stats.army.capped * armyRatio))) {
-                    logOpponent(bR, "armyRatio", {
-                        'armyRatio': armyRatio.dp(2),
-                        'army': bR.army ,
-                        'armyMax': (stats.army.capped * armyRatio).dp()
-                    });
-
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                if (!schedule.since(bR.lostTime, 604800)) {
-                    logOpponent(bR, "We lost to this id this week", '');
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                // don't conquest people that were dead or hiding in the last hour
-                tempTime = $u.setContent(bR.deadTime, 0);
-                if (bR && !bR.newRecord && !schedule.since(tempTime, 3600)) {
-                    logOpponent(bR, "User was dead in the last hour", '');
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                // don't conquest people we've already chained to max in the last 2 days
-                tempTime = $u.setContent(bR.chainTime, 0);
-                if (bR && !bR.newRecord && !schedule.since(tempTime, 86400)) {
-                    logOpponent(bR, "We chained user within 2 days", '');
-                    opponentDiv = null;
-                    boxesDiv = null;
-                    idDiv = null;
-                    playerDiv = null;
-                    armyDiv = null;
-                    return;
-                }
-
-                conquest.targets.push(bR.userId);
-                logOpponent(bR, "match", '');
-
-                opponentDiv = null;
-                boxesDiv = null;
-                idDiv = null;
-                playerDiv = null;
-                armyDiv = null;
-            });
-
-            targets.sort($u.sortBy(true, "score"));
-
-            targets.forEach( function(t) {
-                logOpponent(t, 'sorted', '');
-                conquest.targets.push(t.userId);
-            });
-
-            opponentsSlice = null;
-        } catch (err) {
-            con.error("ERROR in conquest.targeting: " + err.stack);
-        }
-    };
-
-	conquest.testList = [
-		{ method : 'invade',
-			type : 'conq',
-			check : / Army(\d+) .* Army(\d+) .*(-?\d+) Conquest Rank Pts.* (\+1)? XP.*Health (.*) .?\d+ Conquest Rank/i,
-			vars : ['myArmy', 'theirArmy', 'points', 'wl',  'name'],
-			func : function(r) {
-				r.wl = r.wl == '+1' ? 'won' : 'lost';
-				r.att = stats.bonus.api * r.myArmy / r.theirArmy;
-			}
-		},
-		{ method : 'duel',
-			type : 'conq',
-			check : /(\d+) Conquest Rank Pts.* (\+1)? XP.*Health (.*) .?\d+ Conquest Rank/i,
-			vars : ['points', 'wl',  'name'],
-			func : function(r) {
-				r.wl = r.wl == '+1' ? 'won' : 'lost';
-				r.att = stats.bonus.api;
-			}
-		}
-	];
-
-    conquest.getResults = function(page, resultsText) {
-        try {
-            var r = battle.readWinLoss(resultsText, conquest.testList),
-				bR = {},
-                tempTime = 0,
-                chainBP = '',
-                maxChains = 0;
-
-			if (!r) {
-				return false;
-			}
-
-            con.log(1, "Conquest battle result: " + r.wl.ucWords() + ' against ' + r.name + ' in ' + r.type + ' for ' + r.points + ' Conquest Points', r);
-			
-			bR = battle.getRecord(r.userId);
-
-			if (r.wl === 'won') {
-				session.setItem('ReleaseControl', false);
-				con.log(1, "Chain check");
-				//Test if we should chain this guy
-				tempTime = $u.setContent(bR.chainTime, 0);
-				chainBP = config.getItem('ConquestChainBP', '');
-				if (schedule.since(tempTime, 86400) && ((chainBP !== '' && !$u.isNaN(chainBP) && chainBP >= 0))) {
-					if (chainBP !== '' && !$u.isNaN(chainBP) && chainBP >= 0) {
-						if (r.points >= chainBP) {
-							state.setItem("ConquestChainId", bR.userId);
-							con.log(1, "Chain Attack:", bR.userId, "Conquest Points: " + r.points);
-						} else {
-							con.log(1, "Ignore Chain Attack:", bR.userId, "Conquest Points: " + r.points);
-							bR.ignoreTime = Date.now();
-						}
-					}
-				}
-
-				bR.chainCount += 1;
-				maxChains = config.getItem('ConquestMaxChains', 4);
-				if (maxChains === '' || $u.isNaN(maxChains) || maxChains < 0) {
-					maxChains = 4;
-				}
-
-				if (bR.chainCount >= maxChains) {
-					con.log(1, "Lets give this guy a break. Chained", bR.chainCount);
-					bR.chainTime = Date.now();
-					bR.chainCount = 0;
-					bR.ignoreTime = 0;
-					bR.unknownTime = 0;
-				}
-			} else {
-				con.log(1, "Do Not Chain Attack:", bR.userId);
-				bR.chainCount = 0;
-				bR.chainTime = 0;
-				bR.ignoreTime = 0;
-				bR.unknownTime = 0;
-			}
-
-			battle.setRecord(bR);
-	} catch (err) {
-            con.error("ERROR in conquest.getResults: " + err.stack);
-        }
-    };
-
 	conquest.categories = ['Conqueror','Guardian','Hunter','Engineer'];
 
 	worker.addPageCheck({page : 'ajax:guildv2_conquest_command.php?tier=3', hours : 1});
@@ -1120,40 +288,19 @@ schedule,state,general,session */
         }
     };
 	
-    conquest.battle = function(page, resultsText) {
-        try {
-
-			conquest.getResults(page, resultsText);
-
-            var slice = $j("#app_body div[style*='war_conquest_header2.jpg']");
-            if ($u.hasContent(slice)) {
-                conquest.getCommonInfos(slice);
-                conquest.targeting();
-            } else {
-                con.warn("conquest.battle: missing header slice");
-            }
-
-            slice = null;
-        } catch (err) {
-            con.error("ERROR in conquest.battle: " + err.stack);
-        }
-    };
-
     conquest.menu = function() {
         try {
             var XConquestInstructions = "Start battling if Guild Coins is above this points",
                 XMinConquestInstructions = "Do not conquest if Guild Coins is below this points",
-                chainBPInstructions = "Number of conquest points won to initiate a chain attack. Specify 0 to always chain attack.",
                 maxChainsInstructions = "Maximum number of chain hits after the initial attack.",
-                FMRankInstructions = "The lowest relative rank below yours that " + "you are willing to spend your Guild Coins on. Leave blank to attack " + "any rank. (Uses Conquest Rank for invade and duel)",
-                FMARBaseInstructions = "This value sets the base for your Army " + "Ratio calculation [X * (Your Army Size/ Opponent Army Size)]. It is basically a multiplier for the army " +
-                    "size of a player at your equal level. A value of 1 means you " + "will conquest an opponent the same level as you with an army the " + "same size as you or less. Default .5",
-                FreshMeatARMaxInstructions = "This setting sets the highest value you will use for the Army Ratio [Math.min(Army Ratio, Army Ratio Max)] value. " +
-                    "So, if you NEVER want to fight an army bigger than 80% your size, you can set the Max value to .8.",
-                FreshMeatARMinInstructions = "This setting sets the lowest value you will use for the Army Ratio [Math.max(Army Ratio, Army Ratio Min)] value. " +
-                    "So, if you NEVER want to pass up an army that is less than 10% the size of yours, you can set MIN value to .1.",
-                FreshMeatMaxLevelInstructions = "This sets the highest relative level, above yours, that you are willing to attack. So if you are a level 100 and do not want to attack an opponent above level 120, you would code 20.",
-                FreshMeatMinLevelInstructions = "This sets the lowest relative level, below yours, that you are willing to attack. So if you are a level 100 and do not want to attack an opponent below level 60, you would code 40.",
+                minRankInst = "The lowest rank that you are willing to spend your Guild Coins on. " +
+					"Use +/- to indicate relative rank, e.g. -2 to attack opponents down to two ranks below your rank. " +
+					"If no +/-, the number is an absolute rank, e.g. 16 would mean do not attack below rank Baron (16). " +
+					"Leave blank to attack any rank.",
+                maxRankInst = "The highest rank that you are willing to spend your Guild Coins on. " +
+					"Use +/- to indicate relative rank, e.g. +2 to attack opponents up to two ranks over your rank. " +
+					"If no +/-, the number is an absolute rank, e.g. 16 would mean do not attack above rank Baron (16). " +
+					"Leave blank to attack any rank.",
                 conquestList = ['Coins Available', 'At Max Coins', 'At X Coins', 'Never'],
                 conquestInst = [
                     'Guild Coins Available will conquest whenever you have enough Guild Coins',
@@ -1161,7 +308,14 @@ schedule,state,general,session */
                     'At X Guild Coins you can set maximum and minimum Guild Coins to conquest',
                     'Never - disables'
                 ],
+                levelsInst = [
+                    'Pick best target for conquest points, regardless of level bracket',
+                    'Target levels 300 and up',
+                    'Target levels 600 and up',
+                    'Target levels 900 and up'
+                ],
                 typeList = ['Invade', 'Duel'],
+                levelList = ['Any', '300+', '600+', '900+'],
                 typeInst = ['Conquest using Invade button', 'Conquest using Duel button - no guarentee you will win though'],
                 htmlCode = '',
 				catList = [],
@@ -1191,20 +345,11 @@ schedule,state,general,session */
             htmlCode += lom.conquestMenu();
             htmlCode += caap.display.start('WhenLoE', 'isnot', 'Always');
             htmlCode += caap.makeDropDownTR("Conquest Type", 'ConquestType', typeList, typeInst, '', '', false, false, 62);
-            htmlCode += caap.makeCheckTR("Wait For Safe Health", 'conquestWaitSafeHealth', false, '');
-            htmlCode += caap.makeNumberFormTR("Chain Conquest Points", 'ConquestChainBP', chainBPInstructions, '', '');
+            htmlCode += caap.makeDropDownTR("Target Level", 'conquestLevels', levelList, levelsInst, '', 'Any', false, false, 62);
             htmlCode += caap.makeNumberFormTR("Max Chains", 'ConquestMaxChains', maxChainsInstructions, 4, '', '');
             htmlCode += caap.makeTD("Attack targets that are not:");
-            htmlCode += caap.makeNumberFormTR("My Level Minus", 'ConquestMinLevel', FreshMeatMaxLevelInstructions, '', '', '', true);
-            htmlCode += caap.makeNumberFormTR("My Level Plus", 'ConquestMaxLevel', FreshMeatMinLevelInstructions, '', 50, '', true);
-            htmlCode += caap.makeNumberFormTR("My Rank Minus", 'ConquestMinRank', FMRankInstructions, 0, '', '', true);
-            htmlCode += caap.makeNumberFormTR("My Rank Plus", 'ConquestMaxRank', '', 2, '', '', true);
-            htmlCode += caap.makeNumberFormTR("Higher Than X*AR", 'ConquestARBase', FMARBaseInstructions, 0.7, '', '', true);
-            htmlCode += caap.makeCheckTR('Advanced', 'ConquestAdvancedOptions', false);
-            htmlCode += caap.display.start('ConquestAdvancedOptions');
-            htmlCode += caap.makeNumberFormTR("Army Ratio Max", 'ConquestARMax', FreshMeatARMaxInstructions, '', '', '', true);
-            htmlCode += caap.makeNumberFormTR("Army Ratio Min", 'ConquestARMin', FreshMeatARMinInstructions, '', '', '', true);
-            htmlCode += caap.display.end('ConquestAdvancedOptions');
+            htmlCode += caap.makeNumberFormTR("Lower Than Rank", 'ConquestMinRank', minRankInst, '', '', 'text'); // Check +1 works
+            htmlCode += caap.makeNumberFormTR("Higher Than Rank", 'ConquestMaxRank', maxRankInst, '', '', 'text'); // Check +1 works
             htmlCode += caap.display.end('WhenLoE', 'isnot', 'Always');
             htmlCode += caap.display.end('WhenConquest', 'isnot', 'Never');
             htmlCode += caap.endToggle;

--- a/Chrome/unpacked/js/worker_demi.js
+++ b/Chrome/unpacked/js/worker_demi.js
@@ -72,25 +72,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
-	
-	worker.addAction({worker : 'caap', priority : 1200, description : 'Doing Demi Points', functionName : 'demiPoints'});
-    caap.demiPoints = function () {
-        try {
-            if (stats.level < 9 || !battle.demisPointsToDo('set')) {
-                return false;
-            }
-
-            if (schedule.check("battle") && caap.navigateTo(battle.page, 'battle_tab_battle_on.jpg')) {
-				return true;
-            }
-
-            return battle.demisPointsToDo('left') ? battle.worker() : false;
-        } catch (err) {
-            con.error("ERROR in demiPoints: " + err);
-            return false;
-        }
-    };
-
     caap.loadDemi = function () {
         var demis = gm.getItem('demipoint.records', 'default');
         if (demis === 'default' || !$j.isPlainObject(demis)) {

--- a/Chrome/unpacked/js/worker_gsheet.js
+++ b/Chrome/unpacked/js/worker_gsheet.js
@@ -1,8 +1,8 @@
-/*jslint white: true, browser: true, devel: true, undef: true,
+/*jslint white: true, browser: true, devel: true, 
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global window,escape,jQuery,$j,rison,utility,offline,town,
-$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,gsheet,ss,
+/*global window,escape,stats,$j,rison,utility,offline,town,
+$u,chrome,worker,self,caap,config,con,gsheet,ss,
 schedule,gifting,state,army, general,session,monster,guild_monster */
 /*jslint maxlen: 256 */
 
@@ -64,7 +64,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 						if (!$u.hasContent(obj.table) || !$u.hasContent(obj.table.rows)) {
 							con.log(1, 'Gsheet: no match for hash ' + hash + ' found on URL ' + url, data, obj);
 							return;
-						} else if (obj.table.rows.length != 1) {
+						} 
+						if (obj.table.rows.length != 1) {
 							con.log(1, 'Gsheet: too many matches for hash ' + hash + ' found on URL ' + url, data, obj);
 							return;
 						}
@@ -75,7 +76,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 							label = $u.setContent(c.label, '').trim();
 							oldVal = $u.hasContent(label) ? config.getItem(label, 'defaultx') : null;
 							oldVal = oldVal == 'defaultx' ? null : oldVal;
-							newVal = !$u.hasContent(values[i]) || !$u.hasContent(values[i].v) ? null : values[i].v;
+							newVal = !$u.hasContent(values[i]) || !$u.hasContent(values[i].v) ? null : values[i].v == 'blank' ? '' : values[i].v;
 							if (oldVal !== null && newVal !== null && oldVal != newVal) {
 								newVal = $u.isString(oldVal) ? newVal.toString() : newVal;
 								con.log(1, 'Gsheet: Updating config value of ' + label + ' from ' + oldVal

--- a/Chrome/unpacked/js/worker_loe.js
+++ b/Chrome/unpacked/js/worker_loe.js
@@ -86,7 +86,7 @@ schedule,state,general,session,battle:true */
 				which = guild_id == stats.guild.id ? 'your' : 'enemy';
 				fR = gb.getRecord('loe');
 				session.setItem('gbWhich', fR.label);
-				battle.readWinLoss(resultsText, gb.testList);
+				battle.readWinLoss(resultsText, gb.winLoss);
 				
 				towerDivs = which == 'enemy' ? $j('#hover_tab_1_1').closest('.tower_tab').find('div[onmouseover*="hover_tab_1_"]') :
 					$j('div[id^="tower_"]').not('[id*="fort"]').not('[id*="tab"]');

--- a/Chrome/unpacked/js/worker_lom.js
+++ b/Chrome/unpacked/js/worker_lom.js
@@ -122,20 +122,29 @@ schedule,state,general,session,battle:true */
 				
 				fR = gb.getRecord('lom');
 				
-				$j('div[id^="special_defense_button"] form input[type="image"]').each( function() {
-					powers.addToList($j(this).attr('src').regex(/.*\/(\w+\.\w+)/));
-				});
+				// Your health is too low to use a special ability, heal first
 				
-				if ($u.hasContent(powers)) {
-					fR.state = 'Active';
-					session.setItem('gbWhich', fR.label);
-					battle.readWinLoss(resultsText, gb.testList);
-					gb.setrPage(fR, gb.makePath(gb.lom, 'your', slot), 'review', Date.now());
-					gb.readTower(fR, 'your', slot, $j('#your_guild_member_list_1'), powers);
-				} else if (fR.state == 'Active') { 
-				// Add a timeout here in case wasn't in last defend, script wasn't run during protect so not deleted but now defending?
-					con.log(2, 'LoM: No defense actions, so ignoring land ' + slot);
+				if (resultsText.match(/Your health is too low to use a special ability, heal first/)) {
+					con.log(2, 'LoM: Health too low, so disabling LoM guardian until next land', fR);
 					fR.state = 'No Battle';
+					
+				} else {
+					
+					$j('div[id^="special_defense_button"] form input[type="image"]').each( function() {
+						powers.addToList($j(this).attr('src').regex(/.*\/(\w+\.\w+)/));
+					});
+					
+					if ($u.hasContent(powers)) {
+						fR.state = 'Active';
+						session.setItem('gbWhich', fR.label);
+						battle.readWinLoss(resultsText, gb.winLoss);
+						gb.setrPage(fR, gb.makePath(gb.lom, 'your', slot), 'review', Date.now());
+						gb.readTower(fR, 'your', slot, $j('#your_guild_member_list_1'), powers);
+					} else if (fR.state == 'Active') { 
+					// Add a timeout here in case wasn't in last defend, script wasn't run during protect so not deleted but now defending?
+						con.log(2, 'LoM: No defense actions, so ignoring land ' + slot);
+						fR.state = 'No Battle';
+					}
 				}
 				
 				gb.setRecord(fR);

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -70,13 +70,10 @@ gm,hiddenVar,battle,general */
 			},
 			rank: {
 				battle: 0,
-				battlePoints: 0,
 				war: 0,
-				warPoints: 0,
 				conquest: 0,
-				conquestPoints: 0,
-				conquestLevel: 0,
-				conquestLevelPercent: 0
+				festival: 0,
+				conquestLevel: 0
 			},
 			potions: {
 				energy: 0,
@@ -205,6 +202,10 @@ gm,hiddenVar,battle,general */
 		try {
 			var accountName = stats.account;
 			window.stats = statsFunc.getRecord(stats.FBID);
+			if (stats.FBID == 0) {
+				con.log(1, 'Reloading because FBID reset to zero');
+				session.setItem("flagReload", true);
+			}
 			stats.account = accountName;
 			state.deleteItem("statsRaiseDone");
 			
@@ -373,7 +374,7 @@ gm,hiddenVar,battle,general */
 					}
 				}
 				// conquest rank
-				if (stats.level >= 100) {
+				if (stats.level >= 80) {
 					tempDiv = $j("#app_body img[src*='conquest_rank_']");
 					if ($u.hasContent(tempDiv)) {
 						stats.rank.conquest = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
@@ -382,9 +383,19 @@ gm,hiddenVar,battle,general */
 					}
 				}
 
+				// festival rank
+				if (stats.level >= 80) {
+					tempDiv = $j("#app_body img[src*='festival_duelchampion']");
+					if ($u.hasContent(tempDiv)) {
+						stats.rank.festival = $u.setContent($u.setContent(tempDiv.attr("src"), '').basename().regex(/(\d+)/), 0);
+					} else {
+						con.warn('Using stored conquestRank.');
+					}
+				}
+
 				// Check for Gold Stored  STORED: INCOME: UPKEEP: CASH FLOW: $0 $236,345,000/hour -$1,280,430/hour $235,064,570/hour
 				if (caap.bulkRegex(text, /STORED: INCOME: UPKEEP: CASH FLOW: \$([,\d]+) \$([,\d]+)\/hour -\$([,\d]+)\/hour \$([,\d]+)\/hour/,
-					stats.gold,	['bank', 'income', 'upkeep', 'flow'])) {
+					stats.gold,	['bank', 'income', 'upkeep', 'flow'], 'silent')) {
 					['bank', 'income', 'upkeep', 'flow'].forEach( function(e) {
 						stats.gold[e] = stats.gold[e].numberOnly();
 					});
@@ -705,6 +716,10 @@ gm,hiddenVar,battle,general */
 				}
 				break;
 			case 'achievements' :
+
+				// Get favor points -- Just put this here since it's a convenient page visited about once a day
+				stats.points.favor = $u.setContent($j('#persistHomeFPPlateOpen').text(), '').regexd(/(\d+)/, 0);
+				
 				achDiv = $j("#app_body #achievement_info_container_test_of_might_monster div[style*='ach_medalcontainer.jpg']");
 				if ($u.hasContent(achDiv)) {
 					stats.achievements.monster = {};
@@ -991,7 +1006,7 @@ gm,hiddenVar,battle,general */
                     [{
                         text: 'Battle Rank Points'
                     }, {
-                        text: stats.rank.battlePoints.addCommas(),
+                        text: 'Unknown',
                         color: valueCol
                     }, {
                         text: 'Defense'
@@ -1014,7 +1029,7 @@ gm,hiddenVar,battle,general */
                     [{
                         text: 'War Rank Points'
                     }, {
-                        text: stats.rank.warPoints.addCommas(),
+                        text: 'Unknown',
                         color: valueCol
                     }, {
                         text: 'Army'
@@ -1036,7 +1051,7 @@ gm,hiddenVar,battle,general */
                     [{
                         text: 'Conquest Rank Points'
                     }, {
-                        text: stats.rank.conquestPoints.addCommas(),
+                        text: 'Unknown',
                         color: valueCol
                     }, {
                         text: 'Generals When Invade',

--- a/Chrome/unpacked/js/worker_town.js
+++ b/Chrome/unpacked/js/worker_town.js
@@ -24,6 +24,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             'image': '', 
             'name': '',
             'type': '',
+			'item': '',
             'upkeep': 0,
             'hourly': 0,
             'atk': 0,
@@ -42,21 +43,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 		
 	worker.addPageCheck({page : 'magic'});
 	
-	town.init = function() {
-		try {
-			if (gm) {
-				// Should be ok to remove old record lookup after 2015/3/17 - Artifice
-				gm.deleteItem('item.records');
-				gm.deleteItem('magic.records');
-				gm.deleteItem('soldiers.records');
-			}
-       } catch (err) {
-            con.error("ERROR in gb.init: " + err.stack);
-            return false;
-        }
-	};
-
-		
 	town.checkResults = function(page) {
         try {
 			switch (page) {


### PR DESCRIPTION
Battle
Full re-write of battle routines. Including:
Add Festival Duel Champion battles
Unified common functions that handle all battle-type stuff for battle,
conquest, festival duel, and guild battles
Automatic recon at all times. CAAP records all targets it sees on the
battle pages and keeps a list of the best 250 targets
Improve target selection, based on chance to win by level/army of
opponent * number of points for winning
Target rank updating based on points received
Improve chaining. CAAP remembers the last target and will go back to
finish chaining them even if interrupted
Simplify config menu -- Raid stuff hidden and moved under Raid section
only to appear if selected. Level filters for targets removed, since
CAAP will automatically pick the best target by level
Separate Wait for Monster into check box to allow Max Stamina, Between X
Stamina, settings otherwise
Add ability to do relative or absolute rank selection. For example, your
rank +3 ranks or over rank 19, regardless of your rank
Convert to next generation Navigate3 navigation
Net reduction of about 1000 lines of code, even after increased Festival
Duel functionality
Probably break Raid and userId list functionality. Will have to check
those out.

Generals
Add general quick switch for all pages
Enable loadouts reset rebuild -- I said I wasn't going to do this, since
it's CA's bug, but it's taken too long to fix. Of course, now that I've
gone to the trouble of coding a fix, they'll probably fix tomorrow. ;)
Not 100% sure this works yet. Hard to test without a reset.
General level up detection -- CAAP notices when the general level up
pop-up appears and levels up the general
Under level general order changed to default to do lowest level first.
Add check box to config menu to do highest under level first instead.

Conquest Battle
All battle improvements above apply
Add level selection to go for 300+, 600+, or 900+ for better Conqueror
points
Burn tokens when about to do a Conquest level up to get the token refill

Monster Finder
Fix for blank lines
Fix for [0] conditions

GB
Fix for continually trying to rejoin battle that ended early
Fix for select by FB ID conditions

LoE/LoM
Fix check for LoM/LoE defend actions
Add check for low health, and stop LoM defend when health too low

Monster
Fix for monsters joined with zero damage (joined a monster with zero
health or not enough stamina) not registering as joined
Fix dashboard display of title with stamina/energy use for monsters when
using user-set achievement

Other
Add read for Festival Duel Champion rank to keep
Change level up logic to find biggest monster hit or current quest, use
all stamina, use all energy, then do the big hit
Remove some page reviews where the information is read elsewhere, such
as Oracle for FP or Battle Rank page for rank which is on Keep
Expand logged out page check to include pages without the splash page,
so hypervisor can log in account
Add bqh value (CA method for prevention of stale link use) to navigate3
navigation
Add log suppression option for record validation
Add bulk regex mismatch log suppression option
Add "blank" option for google sheet configurations
Add reboot if FB ID not loaded correctly. This happens on FB sometimes
and will cause CAAP to erase all your monsters because it doesn't see
your FB ID in the damage table.