### PR TITLE
Dashboard Workerisation

### DIFF
--- a/Chrome/unpacked/js/caap_dashboard.js
+++ b/Chrome/unpacked/js/caap_dashboard.js
@@ -2,8 +2,8 @@
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
 /*global window,escape,jQuery,$j,rison,utility,
-feed,battle,town,conquest,
-$u,stats,worker,self,caap,config,con,essence,
+feed,battle,town,conquest,ignoreJSLintError,
+$u,stats,worker,self,caap,config,con,essence,gb,
 schedule,gifting,state,army, general,session,monster,guild_monster */
 /*jslint maxlen: 256 */
 
@@ -81,8 +81,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
-    caap.updateDashboardWaitLog = true;
-
     caap.addDashboard = function() {
         try {
             /*-------------------------------------------------------------------------------------\
@@ -90,131 +88,43 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
              container and position it within the main container.
              \-------------------------------------------------------------------------------------*/
             var layout = "<div id='caap_top'>",
-                displayList = [
-                    'Arena Stats',
-                    'Army',
-                    'Battle Stats',
-                    'Feed',
-                    '100v100',
-                    'Generals Stats',
-//                    'Gift Queue',
-//                    'Gifting Stats',
-                    'Guild Essence',
-                    'Guild Monster',
-                    'Classic',
-                    '10v10',
-                    'Monster',
-                    'Target List',
-                    'Town Stats',
-                    'User Stats'
-                ],
-                displayInst = [
-                    'Display your Army Members, the last time they leveled up and choose priority Elite Guard.',
-                    'Display your Battle history statistics, who you fought and if you won or lost.',
-                    'Display the monsters that have been seen in your Live Feed and/or Guild Feed that are still valid.',
-                    'Display the 100v100 battle in progress.',
-                    'Display information about your Generals.',
-//                    'Display your current Gift Queue.',
-//                    'Display your Gifting history, how many gifts you have received and returned to a user.',
-                    'Display Essence Storage space for Guilds that have been scouted.',
-                    'Display information about your Guild Monster.',
-                    'Display the Guild battle in progress.',
-                    'Display the 10v10 battle in progress.',
-                    'Display your Monster battles.',
-                    'Display information about Targets that you have performed reconnaissance on.',
-                    'Display information about items and solders',
-                    'Display information about your account and character statistics.'
-                    ],
+                displayInst = [],
+				dashNames = [],
                     styleXY = {
                         x : 0,
                         y : 0
                     },
-                    bgc = state.getItem("StyleBackgroundLight", "#E0C961");
+					bList = [],
+                    bgc = state.getItem("StyleBackgroundLight", "#E0C961"),
+					confDisF = function(d) {
+						return d == config.getItem('DBDisplay', 'Monster') ? 'block' : 'none';
+					};
 
-            /*-------------------------------------------------------------------------------------\
-            Next we put in our Refresh Monster List button which will only show when we have
-            selected the Monster display.
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonMonster' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'None') === 'Monster' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_refreshMonsters' value='Refresh Monster List' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in our Refresh Feed List button which will only show when we have
-            selected the Feed display.
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonFeed' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'None') === 'Feed' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_refreshFeeds' value='Refresh Feed List' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in our Guild and Festival battle dropdown which will only show when we have
-            selected the Guild or Festival battle display.
-            \-------------------------------------------------------------------------------------*/
-
-            layout += "<div id='caap_GFDisplay' style='font-size: 9px;position:absolute;top:0px;left:250px;display:" + (['100v100','Classic', '10v10'].hasIndexOf(config.getItem('DBDisplay', 'Monster')) ? 'block' : 'none') + "'>Table: ";
-            layout += caap.makeDropDown('GFDisplay', ['Opponent','My Guild'], ['Them','Us'], '', 'Opponent', "font-size: 9px; min-width: 90px; max-width: 90px; width : 90px;") + "</div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in our Refresh Generals List button which will only show when we have
-            selected the Generals display.
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonGenerals' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Generals Stats' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_refreshGenerals' value='Refresh Generals List' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in our Refresh Guild Monster List button which will only show when we have
-            selected the Guild Monster display.
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonGuildMonster' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Guild Monster' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_refreshGuildMonsters' value='Refresh Guild Monster List' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in the Clear Target List button which will only show when we have
-            selected the Target List display
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonTargets' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Target List' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_clearTargets' value='Clear Targets List' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in the Clear Battle Stats button which will only show when we have
-            selected the Target List display
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonBattle' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Battle Stats' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_clearBattle' value='Clear Battle Stats' style='padding: 0; font-size: 9px; height: 18px' /></div>";
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in the Clear Arena Stats button which will only show when we have
-            selected the Target List display
-            \-------------------------------------------------------------------------------------
-            layout += "<div id='caap_buttonArena' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Arena Stats' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_clearArena' value='Clear Arena Stats' style='padding: 0; font-size: 9px; height: 18px' /></div>";*/
-
-            /*-------------------------------------------------------------------------------------\
-            Next we put in the Clear Guild Essence button which will only show when we have
-            selected the Guild Essence display
-            \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_buttonGuilds' style='position:absolute;top:0px;left:250px;display:" + (config.getItem('DBDisplay', 'Monster') === 'Guild Essence' ? 'block' : 'none') + "'>";
-            layout += "<input type='button' id='caap_clearGuilds' value='Clear Guild Essence' style='padding: 0; font-size: 9px; height: 18px' />";
-            layout += "<input type='button' id='caap_rescanGuilds' value='Rescan Essence' style='padding: 0; font-size: 9px; height: 18px' />";
-            layout += "</div>";
-
+			// Add new format dashboards by object
+			worker.dashList.forEach( function(d) {
+				var dO = window[d].dashboard;
+				dashNames.push(dO.name);
+				displayInst.push(dO.inst);
+			});
+			
             /*-------------------------------------------------------------------------------------\
             Then we put in the Guild tokens and FP total since we overlay them on the page.
             \-------------------------------------------------------------------------------------*/
-            layout += "<div style='position:absolute;top:8 px;left:10px;padding: 0; font-size: 9px; height: 18px'><b>Tokens: " + stats.guildTokens.num + '/' + stats.guildTokens.max + ' &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FP: ' + stats.points.favor + "</b></div>";
-//            layout += "<div style='position:absolute;top:0px;left:10px;'><input id='caap_liveFeed' type='button' value='Live Feed' style='padding: 0; font-size: 9px; height: 18px' /></div>";
+            layout += "<div style='position:absolute;top:8 px;left:10px;padding: 0; font-size: 9px; height: 18px'><b>Tokens: " +
+				stats.guildTokens.num + '/' + stats.guildTokens.max + ' &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FP: ' + stats.points.favor + "</b></div>";
 
             /*-------------------------------------------------------------------------------------\
-             Then we put in the Raid link since no longer available through interface.
+             Then we put in the Raid link since no longer available through normal CA web page.
              \-------------------------------------------------------------------------------------*/
             layout += "<div style='position:absolute;top:0px;left:140px;'><a href='raid.php' onclick=\"ajaxLinkSend('globalContainer'," +
-				"'raid.php'); return false;\"><input type='button' value='Raid' style='padding: 0; font-size: 9px; height: 18px' /></a></div>";
+				"'raid.php'); return false;\"><input type='button' value='&nbsp;Raid&nbsp;' style='padding: 0; font-size: 9px; height: 18px' /></a></div>";
 
             /*-------------------------------------------------------------------------------------\
             We install the display selection box that allows the user to toggle through the
             available displays.
             \-------------------------------------------------------------------------------------*/
             layout += "<div id='caap_DBDisplay' style='font-size: 9px;position:absolute;top:0px;right:25px;'>Display: ";
-            layout += caap.makeDropDown('DBDisplay', displayList, displayInst, '', 'User Stats', "font-size: 9px; min-width: 90px; max-width: 90px; width : 90px;") + "</div>";
+            layout += caap.makeDropDown('DBDisplay', dashNames, displayInst, '', 'User Stats', "font-size: 9px; min-width: 90px; max-width: 90px; width : 90px;") + "</div>";
 
             /*-------------------------------------------------------------------------------------\
             We install the minimize/maximise button that allows the user to make the dashboard
@@ -223,24 +133,64 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             layout += "<div id='caap_dashMin' class='ui-icon ui-icon-circle-minus' style='position:absolute;top:0px;right:5px;' title='Minimise' onmouseover='this.style.cursor=\"pointer\";' onmouseout='this.style.cursor=\"default\";'>-</div>";
 
             /*-------------------------------------------------------------------------------------\
-            And here we build our empty content divs.  We display the appropriate div
-            depending on which display was selected using the control above
+            And here we build our empty content divs and buttons.  All are built hidden, and 
+			will be revealed if selected by caap.updateDashboard()
             \-------------------------------------------------------------------------------------*/
-            layout += "<div id='caap_infoMonster' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Monster' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_guildMonster' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Guild Monster' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_gbClassic' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Classic' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_gb10' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === '10v10' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_infoTargets1' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Target List' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_infoBattle' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Battle Stats' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_infoArena' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Arena Stats' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_userStats' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'User Stats' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_generalsStats' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Generals Stats' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_Town_Stats' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Town Stats' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_army' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Army' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_gb100' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === '100v100' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_infoFeed' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Feed' ? 'block' : 'none') + "'></div>";
-            layout += "<div id='caap_infoGuilds' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + (config.getItem('DBDisplay', 'Monster') === 'Guild Essence' ? 'block' : 'none') + "'></div>";
-            layout += "</div>";
+			worker.dashList.forEach( function(d) {
+				var wO = window[d],
+					dO = $u.extend({}, {buttons : [], tableTemplate: {}, handlers: [], tableEntries: []}, wO.dashboard),
+					i= dO.buttons.indexOf('clear'),
+					bText = [];
+					
+				layout += "<div id='caap_dash_" + dO.name.underline() + "' class='caap_dash_" + dO.name.underline() +
+					"' style='position:relative;top:15px;width:610px;height:165px;overflow:auto;display:" + confDisF(dO.name) + "'></div>";
+					
+				if (i >= 0) {
+					dO.buttons[i] = {name: 'Clear ' + dO.name + ' Records',
+						func: function() {
+							window[dO.records].records = [];
+							window[dO.records].save('update');
+						}
+					};
+				}
+					
+				dO.tableEntries.forEach( function(e, i) {
+					// Add remove buttons
+					if (e.type == 'remove') {
+						e = {name: '&nbsp;', format: 'unsortable',
+							valueF: function(r) {
+								return '<span title="Clicking this link will remove ' + r[$u.setContent(e.name, wO.recordIndex)] +
+								' from CAAP" class="caap_' + dO.records + '_remove ui-icon ui-icon-circle-close" rlink="' +
+								r[wO.recordIndex] + '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">X</span>';
+						}};
+						dO.tableEntries[i] = e;
+						dO.handlers.addToList({
+							hClass: dO.records + '_remove',
+								handleF: function(e) {
+									$j.makeArray(e.target.attributes).some( function(n) {
+										if (n.nodeName === 'rlink') {
+											wO.deleteRecord(n.value);
+											wO.save('update');
+											return true;
+										}
+									});
+								}
+						});
+						window[d].dashboard = dO;
+					}
+				});
+					
+				if ($u.hasContent(dO.buttons)) {
+					layout += '<div class="caap_dash_' + dO.name.underline() + '" style="position:absolute;top:2px;left:200px;display:' + 
+						confDisF(dO.name) + '">';
+					dO.buttons.forEach( function(b) {
+						bText.push('<input type="button" id="caap_dashButton_' + b.name.underline() + '" value="&nbsp;' + b.name +
+							'&nbsp;" style="padding: 0; font-size: 9px; height: 18px;" />');
+						bList.addToList(b);
+					});
+					layout += bText.join('&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;') + "</div>";
+				}
+			});
 
             /*-------------------------------------------------------------------------------------\
             No we apply our CSS to our container
@@ -265,6 +215,14 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
             caap.caapTopObject = $j('#caap_top');
             $j("input[type='button']", caap.caapTopObject).button();
+			
+			// Add button handlers
+			bList.forEach( function(b) {
+				$j("input[id='caap_dashButton_" + b.name.underline() + "']", caap.caapTopObject).off('click', b.func).on('click', b.func);
+			});
+			
+			caap.updateDashboard();
+
             return true;
         } catch (err) {
             con.error("ERROR in addDashboard: " + err.stack);
@@ -328,26 +286,98 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             if (caap.caapTopObject.length === 0) {
                 throw "We are missing the Dashboard div!";
             }
-
-/*            if (!caap.oneMinuteUpdate('dashboard', force)) {
-                if (caap.updateDashboardWaitLog) {
-                    con.log(4, "Dashboard update is waiting on oneMinuteUpdate");
-                    caap.updateDashboardWaitLog = false;
-                }
-
-                return false;
-            }
-*/
-            caap.updateDashboardWaitLog = true;
-            con.log(3, "Updating Dashboard");
-			worker.list.forEach( function(i) {
-				if ($u.isFunction(window[i].dashboard)) {
-					window[i].dashboard();
+			
+			var activeDash = config.getItem('DBDisplay', 'None');
+				
+			worker.dashList.some( function(d) {
+				var wO = window[d],
+					dO = $u.extend({}, {buttons : [], tableTemplate: {}, handlers: [], tableEntries: []}, wO.dashboard),
+					ulName = dO.name.underline(),
+					tt = dO.tableTemplate,
+					head = '',
+					body = '',
+					fR = $u.hasContent(dO.gbLabel) ? gb.getRecord(dO.gbLabel) : {},
+					tE = $u.isFunction(dO.tableEntriesF) ? dO.tableEntriesF(fR) : dO.tableEntries,
+					records = $u.hasContent(fR) ? fR[config.getItem('gbDashWhich', 'enemy')].members : window[dO.records].records,
+					indices = function(format) {  
+						return tE.map( function(c, i) {
+							ignoreJSLintError(c);
+							return i;
+						}).filter( function(i) {
+							return tE[i].format == format;
+						});		
+					};
+					
+				if (activeDash != dO.name) {
+					return false;  // Wrong dashboard
 				}
+
+				if (!force && !session.getItem("DashUpdate" + ulName, true)) {
+					return true; // Right dashboard, but it's up to date
+				}
+				con.log(2, "Updating " + dO.name + " Dashboard ");
+				
+				if ($u.hasContent(tE)) {
+
+					tE.forEach( function(e) {
+						head += caap.makeTh({text: e.name, width: e.width});
+					});
+					$j.each(records, function(i, r) {
+						ignoreJSLintError(i);
+						if ($u.isFunction(dO.filterF) && !dO.filterF(r)) {
+							return;
+						}
+						var row = '';
+						tE.forEach( function(e) {
+							var text = $u.isDefined(e.value) ? r[e.value] : $u.isFunction(e.valueF) ? e.valueF(r, i) : r[e.name.toLowerCase()];
+							switch (e.format) {
+							case 'time' : 			text = $u.minutes2hours(text); 										break;
+							case 'nonnegative' : 	text = (text < 0 ? '' : text);										break;
+							case '$SI' : 			text = '$' + text.SI();		 										break;
+							case 'SI' : 			text = text.SI();			 										break;
+							default :																					break;
+							}
+
+							text = e.format != 'text' && $u.hasContent(text) && Number(text) == text ? Number(text).dp(1).addCommas() : text;
+							row += caap.makeTd({
+								text: text,
+								// Order: table entry from record, table entry function, table template fixed value, table template function, blank
+								color: $u.isString(e.color) ? r[e.color] : $u.isFunction(e.colorF) ? e.colorF(r) :
+									$u.isDefined(tt.color) ? tt.color : $u.isFunction(tt.colorF) ? tt.colorF(r) : '' ,
+								title: $u.isString(e.title) ? r[e.title] : $u.isFunction(e.titleF) ? e.titleF(r) : 
+									$u.isDefined(tt.title) ? tt.title : $u.isFunction(tt.titleF) ? tt.titleF(r) : ''
+							});
+						});
+						body += caap.makeTr(row);
+					});
+					
+					$j("#caap_dash_" + ulName, caap.caapTopObject).html(
+					$j(caap.makeTable(d, head, body)).dataTable({
+						"bAutoWidth": false,
+						"bFilter": false,
+						"bJQueryUI": false,
+						"bInfo": false,
+						"bLengthChange": false,
+						"bPaginate": false,
+						"bProcessing": false,
+						"bStateSave": true,
+						"bSortClasses": false,
+						"aoColumnDefs": [{"bSortable": false, 		"aTargets": indices('unsortable') },
+							{"sSortDataType": "remaining-time", 	"aTargets": indices('time')}]
+					}));
+				}
+				
+				if ($u.isFunction(dO.headerF)) {
+					$j("#caap_dash_" + ulName, caap.caapTopObject).prepend(dO.headerF(fR));
+				}
+				
+				dO.handlers.forEach( function(h) {
+					$j("span[class*='caap_" + h.hClass + "']", caap.caapTopObject).off('click', h.handleF).on('click', h.handleF);
+				});
+				session.setItem("DashUpdate" + ulName, false);
+				return true;
 			});
-
-            guild_monster.dashboard();
-
+			
            return true;
         } catch (err) {
             con.error("ERROR in updateDashboard: " + err);
@@ -360,145 +390,20 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
     \-------------------------------------------------------------------------------------*/
     caap.dbDisplayListener = function (e) {
         var idName = e.target.id.stripCaap(),
-            value = e.target.options[e.target.selectedIndex].value,
-            title = e.target.options[e.target.selectedIndex].title;
+            value = e.target.options[e.target.selectedIndex].value;
 
-        con.log(1, 'Change: dashboard setting "' + idName + '" to "' + value + '" with title "' + title + '"');
+        con.log(1, 'Change: dashboard setting "' + idName + '" to "' + value + '"');
         config.setItem(idName, value);
-        e.target.title = title;
-        caap.setDisplay("caapTopObject", 'infoMonster', false);
-        caap.setDisplay("caapTopObject", 'guildMonster', false);
-        caap.setDisplay("caapTopObject", 'gbClassic', false);
-        caap.setDisplay("caapTopObject", 'infoArena', false);
-        caap.setDisplay("caapTopObject", 'gb100', false);
-        caap.setDisplay("caapTopObject", 'gb10', false);
-        caap.setDisplay("caapTopObject", 'infoFeed', false);
-        caap.setDisplay("caapTopObject", 'army', false);
-        caap.setDisplay("caapTopObject", 'infoTargets1', false);
-        caap.setDisplay("caapTopObject", 'infoBattle', false);
-        caap.setDisplay("caapTopObject", 'infoGuilds', false);
-        caap.setDisplay("caapTopObject", 'userStats', false);
-        caap.setDisplay("caapTopObject", 'generalsStats', false);
-        caap.setDisplay("caapTopObject", 'Town_Stats', false);
-        caap.setDisplay("caapTopObject", 'buttonMonster', false);
-        caap.setDisplay("caapTopObject", 'buttonFeed', false);
-        caap.setDisplay("caapTopObject", 'GFDisplay', false);
-        caap.setDisplay("caapTopObject", 'buttonGuildMonster', false);
-        caap.setDisplay("caapTopObject", 'buttonTargets', false);
-        caap.setDisplay("caapTopObject", 'buttonGenerals', false);
-        caap.setDisplay("caapTopObject", 'buttonBattle', false);
-        caap.setDisplay("caapTopObject", 'buttonGuilds', false);
-        caap.setDisplay("caapTopObject", 'buttonArmy', false);
-        switch (value) {
-            case "Target List":
-                caap.setDisplay("caapTopObject", 'infoTargets1', true);
-                caap.setDisplay("caapTopObject", 'buttonTargets', true);
+		
+		// Hide all dash objects
+		$j('#caap_top div[class^="caap_dash_"]:visible').each( function() {
+			$j(this).css('display', 'none');
+		});
+		
+		// Unhide the objects from this dash
+		caap.setDisplay("caapTopObject", {'class' : 'dash_' + value.underline()}, true);
 
-                break;
-            case "Battle Stats":
-                caap.setDisplay("caapTopObject", 'infoBattle', true);
-
-                break;
-            case "Arena Stats" :
-                caap.setDisplay("caapTopObject", 'infoArena', true);
-                //caap.setDisplay("caapTopObject", 'buttonBattle', true);
-                break;
-            case "Guild Essence":
-                caap.setDisplay("caapTopObject", 'infoGuilds', true);
-                caap.setDisplay("caapTopObject", 'buttonGuilds', true);
-
-                break;
-            case "User Stats":
-                caap.setDisplay("caapTopObject", 'userStats', true);
-
-                break;
-            case "Generals Stats":
-                caap.setDisplay("caapTopObject", 'generalsStats', true);
-                caap.setDisplay("caapTopObject", 'buttonGenerals', true);
-
-                break;
-            case "Town Stats":
-                caap.setDisplay("caapTopObject", 'Town_Stats', true);
-
-                break;
-            case "Guild Monster":
-                caap.setDisplay("caapTopObject", 'guildMonster', true);
-                caap.setDisplay("caapTopObject", 'buttonGuildMonster', true);
-
-                break;
-            case "Classic":
-				caap.setDisplay("caapTopObject", 'GFDisplay', true);
-                caap.setDisplay("caapTopObject", 'gbClassic', true);
-
-                break;
-            case "Monster":
-                caap.setDisplay("caapTopObject", 'infoMonster', true);
-                caap.setDisplay("caapTopObject", 'buttonMonster', true);
-                break;
-            case "100v100":
-				caap.setDisplay("caapTopObject", 'GFDisplay', true);
-                caap.setDisplay("caapTopObject", 'gb100', true);
-
-                break;
-            case "10v10":
-				caap.setDisplay("caapTopObject", 'GFDisplay', true);
-                caap.setDisplay("caapTopObject", 'gb10', true);
-
-                break;
-            case "Feed":
-                caap.setDisplay("caapTopObject", 'infoFeed', true);
-                caap.setDisplay("caapTopObject", 'buttonFeed', true);
-
-                break;
-            case "Army":
-                caap.setDisplay("caapTopObject", 'army', true);
-                caap.setDisplay("caapTopObject", 'buttonArmy', true);
-
-                break;
-            default:
-				break;
-        }
-
-        caap.updateDashboard(true);
-    };
-
-    /*-------------------------------------------------------------------------------------\
-    addDBListener creates the listener for guild battles control.
-    \-------------------------------------------------------------------------------------*/
-    caap.gfDisplayListener = function (e) {
-        var idName = e.target.id.stripCaap(),
-            value = e.target.options[e.target.selectedIndex].value,
-            title = e.target.options[e.target.selectedIndex].title;
-
-        con.log(1, 'Change: setting "' + idName + '" to "' + value + '" with title "' + title + '"');
-        config.setItem(idName, value);
-        e.target.title = title;
-        caap.setDisplay("caapTopObject", 'yourgb100', value == 'My Guild');
-        caap.setDisplay("caapTopObject", 'yourgbClassic', value == 'My Guild');
-        caap.setDisplay("caapTopObject", 'enemygb100', value == 'Opponent');
-        caap.setDisplay("caapTopObject", 'yourgb10', value == 'My Guild');
-        caap.setDisplay("caapTopObject", 'enemygb10', value == 'Opponent');
-        caap.setDisplay("caapTopObject", 'enemygbClassic', value == 'Opponent');
-        caap.updateDashboard(true);
-    };
-
-	// Pass through function used to pass arguments that might not be referred from a different context
-    caap.refreshFeedListener = function () {
-        monster.fullReview('Feed');
-    };
-
-    caap.refreshGeneralsListener = function () {
-		con.log(1, 'Cleared all general records');
-        general.records = [];
-		general.save();
-    };
-
-    caap.refreshGuildMonstersListener = function () {
-        con.log(1, "refreshGuildMonstersListener");
-        session.setItem('ReleaseControl', true);
-        guild_monster.clear();
-        caap.updateDashboard(true);
-        schedule.setItem("guildMonsterReview", 0);
+        caap.updateDashboard();
     };
 
     caap.getBQH = function (cb) {
@@ -565,16 +470,6 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             }
 
             $j('#caap_DBDisplay', caap.caapTopObject).on('change', caap.dbDisplayListener);
-            $j('#caap_GFDisplay', caap.caapTopObject).on('change', caap.gfDisplayListener);
-            $j('#caap_refreshMonsters', caap.caapTopObject).on('click', monster.fullReview);
-            $j('#caap_refreshFeeds', caap.caapTopObject).on('click', caap.refreshFeedListener);
-            $j('#caap_refreshGenerals', caap.caapTopObject).on('click', caap.refreshGeneralsListener);
-            $j('#caap_refreshGuildMonsters', caap.caapTopObject).on('click', caap.refreshGuildMonstersListener);
-            $j('#caap_clearTargets', caap.caapTopObject).on('click', caap.clearTargetsButtonListener);
-            $j('#caap_clearBattle', caap.caapTopObject).on('click', caap.clearBattleButtonListener);
-            $j('#caap_clearGuilds', caap.caapTopObject).on('click', caap.clearGuildsButtonListener);
-            $j('#caap_rescanGuilds', caap.caapTopObject).on('click', caap.rescanGuildsButtonListener);
-            $j('#caap_getArmy', caap.caapTopObject).on('click', caap.getArmyButtonListener);
             $j('#caap_dashMin', caap.caapTopObject).on('click', function () {
                 caap.caapTopObject.toggle('fold', {}, '', function () {
                     caap.caapTopMinObject.show();

--- a/Chrome/unpacked/js/caap_display.js
+++ b/Chrome/unpacked/js/caap_display.js
@@ -250,6 +250,64 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
+    caap.setDisplay = function (area, idName, display, quiet) {
+        try {
+            if (!$u.hasContent(idName)) {
+                con.warn("idName", idName);
+                throw "Bad idName!";
+            }
+
+            var areaDiv = caap[area],
+                areatest = area,
+				attr = 'id';
+				
+			if ($u.isObject(idName)) {
+				attr = Object.keys(idName).pop();
+				idName = idName[attr];
+			}
+
+            if (!$u.hasContent(areaDiv)) {
+                areatest = "default";
+                areaDiv = $j(document.body);
+                con.warn("Unknown area. Using document.body", area);
+            }
+
+            con.log(2, "Change: display of 'caap_" + idName + "' to '" + (display === true ? 'block' : 'none') + "'", areatest);
+			areaDiv = $j('div[' + attr + '="caap_' + idName + '"]', areaDiv);
+            if (!$u.hasContent(areaDiv) && !quiet) {
+                con.warn("Unable to find idName in area!", idName, area);
+				return false;
+            }
+            areaDiv.each( function() {
+				$j(this).css('display', display === true ? 'block' : 'none');
+			});
+
+            return true;
+        } catch (err) {
+            con.error("ERROR in setDisplay: " + err.stack);
+            return false;
+        }
+    };
+
+    caap.setDisplayById = function (idName) {
+        try {
+			$j("div[id^='caap_displayIf__" + idName + "__is']").each( function() {
+				var id = $j(this).attr('id'),					
+					arr = id.regex(/caap_displayIf__(\w+)__(is|isnot)__(\w+)/);
+				if (arr) {
+					caap.setDisplay('', id.replace('caap_',''), (config.getItem(arr[0], false).toString() == arr[2].replace(/_/g,' ')) == (arr[1] == 'is'));
+				} else {
+					con.warn('caap.dropBoxListener: Unable to parse setting change for id ' + id);
+				}
+			});
+
+            return true;
+        } catch (err) {
+            con.error("ERROR in setDisplayById: " + err.stack);
+            return false;
+        }
+    };
+
 	caap.display = {};
 	
 	// If config setting for idName is the same as test, display

--- a/Chrome/unpacked/js/head.js
+++ b/Chrome/unpacked/js/head.js
@@ -7,7 +7,7 @@
 // @license        GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // ==/UserScript==
 
-/*jslint white: true, browser: true, devel: true, undef: true,
+/*jslint white: true, browser: true, devel: true, 
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
 /*global window,escape,jQuery,$j,rison,utility,
@@ -53,6 +53,14 @@ String.prototype.stripCaap = function() {
     return this.replace(/caap_/i, '');
 };
 
+String.prototype.spaces = function() {
+    return this.replace('_', ' ');
+};
+
+String.prototype.underline = function() {
+    return this.replace(/ /g, '_');
+};
+
 String.prototype.numberOnly = function() {
     return parseFloat(this.replace(new RegExp("[^\\d\\.]", "g"), ''));
 };
@@ -94,7 +102,7 @@ Array.prototype.sum = function() {
 	return this.reduce(function(a,b) {
 		return a+b;
 	}, 0);
-}
+};
 
 Array.prototype.removeFromList = function(v) {
 	var i = this.indexOf(v);
@@ -154,3 +162,7 @@ String.prototype.parseTimer = function() {
 
     return b;
 };
+
+function ignoreJSLintError() {
+	1;
+}

--- a/Chrome/unpacked/js/worker.js
+++ b/Chrome/unpacked/js/worker.js
@@ -14,10 +14,13 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
     "use strict";
 
 	window.worker = {};
-	
 	worker.list = [];
+	worker.dashList = [];
+	worker.dashRecords = [];
+	
 	worker.add = function(n) {
 		var o = $u.isObject(n) ? n : {};
+			
 		
 		o.name = $u.setContent(o.name, n);
 		window[o.name] = $u.setContent(window[o.name], {});
@@ -80,13 +83,9 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					con.warn(wO.name + ': Converted number indexed record(s) for ' + arr.join(', ') + ' to string record(s)');
 					state.setItem('wsave_' + wO.name, true);
 				}
-
-				if ($u.isFunction(wO.dashboard) && caap.domain.which !== 0) {
-					session.setItem(wO.name + 'DashUpdate', true);
-				}
 			};
 
-			wO.save = function(src) {
+			wO.save = function(option) {
 				var newR = new wO.record().data,
 					undefinedKeyList = [];
 					
@@ -108,14 +107,24 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					caap.messaging.setItem(wO.name, wO.records);
 				} else {
 					gm.setItem(wO.name, wO.records, wO.hBest, false);
-					if (caap.domain.which === 0 && caap.messaging.connected.hasIndexOf("caapif") && src !== "caapif") {
+					if (caap.domain.which === 0 && caap.messaging.connected.hasIndexOf("caapif") && option !== "caapif") {
 						caap.messaging.setItem(wO.name, wO.records);
 					}
 				}
-				if ($u.isFunction(wO.dashboard) && caap.domain.which !== 0) {
-					session.setItem(wO.name + 'DashUpdate', true);
-				}
+
 				state.deleteItem('wsave_' + wO.name);
+				
+				if ($u.isObject(wO.dashboard) && caap.domain.which !== 0) {
+					worker.dashRecords.forEach( function(dO) {
+						if (dO.records == wO.name) {
+							session.setItem('DashUpdate' + dO.dash.underline(), true);
+						}
+					});
+				}
+				if (option == 'update') {
+					caap.updateDashboard();
+				}
+				
 			};
 			
 			wO.hasRecord = function(n) {

--- a/Chrome/unpacked/js/worker_army.js
+++ b/Chrome/unpacked/js/worker_army.js
@@ -1,8 +1,8 @@
-/*jslint white: true, browser: true, devel: true, undef: true,
+/*jslint white: true, browser: true, devel: true,
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global window,escape,jQuery,$j,rison,utility,gm,ss,
-$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,sort,
+/*global window,escape,stats,$j,rison,utility,gm,ss,
+$u,chrome,worker,self,caap,config,con,sort,
 schedule,gifting,state,army, general,session,monster,guild_monster */
 /*jslint maxlen: 256 */
 
@@ -69,6 +69,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				break;
 			case 'army_member' :
 				army.page();
+				break;
 			default:
 				break;
 			}
@@ -262,7 +263,8 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				con.warn('Army Add: no text field to enter army code', $j("input[name='army_code']").val(), addCode);
 				schedule.setItem('lastArmyAdd', 300);
 				return false;
-			} else if ($j("input[name='army_code']").val() != addCode) {
+			} 
+			if ($j("input[name='army_code']").val() != addCode) {
 				$j("input[name='army_code']").val(addCode);
 				return true;
 			}
@@ -274,7 +276,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				return false;
 			}
 			caap.click(inviteButton);
-			armyCodes = armyCodes.replace(new RegExp('\s*' + addCode + '\s*'), '').trim();
+			armyCodes = armyCodes.replace(new RegExp('\\s*' + addCode + '\\s*'), '').trim();
 			con.log(1, 'Army Add: Invited ' + addCode + ', ' + invites + ' invites, and ' + armyCodesLeft + ' codes left',armyCodes);
 			config.setItem('army_codes',armyCodes);
 			$j('#caap_army_codes').val(armyCodes); 
@@ -505,273 +507,53 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         }
     };
 
-    army.dashboard = function () {
-        try {
-            /*-------------------------------------------------------------------------------------\
-            Next we build the HTML to be included into the 'caap_army' div. We set our
-            table and then build the header row.
-            \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Army' && session.getItem("ArmyDashUpdate", true)) {
-                var headers = ['UserId', 'User', 'Name', 'Level', 'Change', 'Elite', '&nbsp;'],
-                    values = ['userId', 'user', 'name', 'lvl', 'change'],
-                    color = '',
-                    pp = 0,
-                    i = 0,
-                    userIdLink = '',
-                    userIdLinkInstructions = '',
-                    removeLinkInstructions = '',
-                    len = 0,
-                    len1 = 0,
-                    str = '',
-                    header = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: ''
-                    },
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    handler = null,
-                    head = '',
-                    body = '',
-                    row = '',
-                    tempVar;
-
-                for (pp = 0; pp < headers.length; pp += 1) {
-                    header = {
-                        text: headers[pp],
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: ''
-                    };
-
-                    switch (headers[pp]) {
-                        case 'UserId':
-                            header.width = '18%';
-                            break;
-                        case 'User':
-                            header.width = '27%';
-                            break;
-                        case 'Name':
-                            header.width = '30%';
-                            break;
-                        case 'Level':
-                            header.width = '7%';
-                            break;
-                        case 'Change':
-                            header.width = '10%';
-                            break;
-                        case 'Elite':
-                            header.width = '7%';
-                            break;
-                        case '&nbsp;':
-                            header.width = '1%';
-                            break;
-                        default:
-                    }
-
-                    head += caap.makeTh(header);
-                }
-
-                head = caap.makeTr(head);
-                for (i = 0, len = army.records.length; i < len; i += 1) {
-                    if (army.records[i].userId > 0) {
-                        row = "";
-                        if (schedule.since(army.records[i].change, config.getItem("ArmyAgeDays4", 28) * 86400)) {
-                            color = config.getItem("ArmyAgeDaysColor4", 'red');
-                        } else if (schedule.since(army.records[i].change, config.getItem("ArmyAgeDays3", 21) * 86400)) {
-                            color = config.getItem("ArmyAgeDaysColor3", 'darkorange');
-                        } else if (schedule.since(army.records[i].change, config.getItem("ArmyAgeDays2", 14) * 86400)) {
-                            color = config.getItem("ArmyAgeDaysColor2", 'gold');
-                        } else if (schedule.since(army.records[i].change, config.getItem("ArmyAgeDays1", 7) * 86400)) {
-                            color = config.getItem("ArmyAgeDaysColor1", 'greenyellow');
-                        } else {
-                            color = config.getItem("ArmyAgeDaysColor0", 'green');
-                        }
-
-                        for (pp = 0, len1 = values.length; pp < len1; pp += 1) {
-                            if (values[pp] === "change") {
-                                row += caap.makeTd({
-                                    text: $u.hasContent(army.records[i][values[pp]]) && ($u.isString(army.records[i][values[pp]]) || army.records[i][values[pp]] > 0) ? $u.makeTime(army.records[i][values[pp]], "d-m-Y") : '',
-                                    bgcolor: color,
-                                    color: $u.bestTextColor(color),
-                                    id: '',
-                                    title: ''
-                                });
-                            } else if (values[pp] === "userId") {
-                                str = $u.setContent(army.records[i][values[pp]], '');
-                                userIdLinkInstructions = "Clicking this link will take you to the user keep of " + str;
-                                userIdLink = "keep.php?casuser=" + str;
-                                data = {
-                                    text: '<span id="caap_targetarmy_' + i + '" title="' + userIdLinkInstructions + '" rlink="' + userIdLink + '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + str + '</span>',
-                                    color: 'blue',
-                                    id: '',
-                                    title: ''
-                                };
-
-                                row += caap.makeTd(data);
-                            } else if (values[pp] === "user") {
-                                tempVar = army.records[i].appUser ? '' : config.getItem("ArmyAgeDaysColor4", 'red');
-                                userIdLinkInstructions = "Clicking this link will take you to the Facebook page of " + army.records[i][values[pp]];
-                                row += caap.makeTd({
-                                    text: $u.hasContent(army.records[i][values[pp]]) && ($u.isString(army.records[i][values[pp]]) || army.records[i][values[pp]] > 0) ? "<a href='http://www.facebook.com/profile.php?id=" +
-                                        army.records[i].userId + "'>" + army.records[i][values[pp]] + "</a>" : '',
-                                    bgcolor: tempVar,
-                                    color: $u.hasContent(tempVar) ? $u.bestTextColor(tempVar) : '',
-                                    id: '',
-                                    title: $u.hasContent(tempVar) ? 'User has either blocked Castle Age or is no longer a friend.' : userIdLinkInstructions
-                                });
-                            } else {
-                                row += caap.makeTd({
-                                    text: $u.hasContent(army.records[i][values[pp]]) && ($u.isString(army.records[i][values[pp]]) || army.records[i][values[pp]] > 0) ? army.records[i][values[pp]] : '',
-                                    color: '',
-                                    id: '',
-                                    title: ''
-                                });
-                            }
-                        }
-
-                        data = {
-                            text: '<input id="caap_elitearmy_' + i + '" type="checkbox" title="Use to fill elite guard first" userid="' + army.records[i].userId +
-                                '" cstate="' + (army.records[i].elite ? 'true' : 'false') + '" ' + (army.records[i].elite ? ' checked' : '') + ' />',
-                            color: 'blue',
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-
-                        tempVar = $u.setContent(army.records[i].user, '').escapeHTML();
-                        removeLinkInstructions = "Clicking this link will remove " + tempVar + " from your army!";
-                        data = {
-                            text: '<span id="caap_removearmy_' + i + '" title="' + removeLinkInstructions + '" userid="' + army.records[i].userId + '" mname="' + tempVar +
-                                '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';" class="ui-icon ui-icon-circle-close">X</span>',
-                            color: 'blue',
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-                        body += caap.makeTr(row);
-                    }
-                }
-
-                $j("#caap_army", caap.caapTopObject).html(
-                    $j(caap.makeTable("army", head, body)).dataTable({
-                        "bAutoWidth": false,
-                        "bFilter": false,
-                        "bJQueryUI": false,
-                        "bInfo": false,
-                        "bLengthChange": false,
-                        "bPaginate": false,
-                        "bProcessing": false,
-                        "bStateSave": true,
-                        "bSortClasses": false,
-                        "aoColumnDefs": [{
-                            "bSortable": false,
-                            "aTargets": [6]
-                        }, {
-                            "sSortDataType": "dom-checkbox",
-                            "aTargets": [5]
-                        }, {
-                            "sSortDataType": "scan-date",
-                            "aTargets": [4]
-                        }]
-                    })
-                );
-
-                handler = function (e) {
-                    var visitUserIdLink = {
-                        rlink: '',
-                        arlink: ''
-                    },
-                    i = 0,
-                        len = 0;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'rlink') {
-                            visitUserIdLink.rlink = e.target.attributes[i].nodeValue;
-                            visitUserIdLink.arlink = visitUserIdLink.rlink;
-                        }
-                    }
-
-                    caap.ajaxLink(visitUserIdLink.arlink);
-                };
-
-                $j("span[id*='caap_targetarmy_']", caap.caapTopObject).off('click', handler).on('click', handler);
-                handler = null;
-
-                handler = function (e) {
-                    var userid = 0,
-                        cstate = false,
-                        i = 0,
-                        len = 0,
-                        record = {};
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'userid') {
-                            userid = e.target.attributes[i].nodeValue.parseInt();
-                        } else if (e.target.attributes[i].nodeName === 'cstate') {
-                            cstate = e.target.attributes[i].nodeValue === 'true' ? true : false;
-                        }
-                    }
-
-                    if ($u.hasContent(userid) && userid > 0) {
-                        record = this.getRecord(userid);
-                        record.elite = !cstate;
-                        this.setRecord(record);
-                        session.setItem("ArmyDashUpdate", true);
-                        caap.updateDashboard(true);
-                    }
-                };
-
-                $j("input[id*='caap_elitearmy_']", caap.caapTopObject).off('change', handler).on('change', handler);
-                handler = null;
-
-                handler = function (e) {
-                    var mname = '',
-                        userid = '',
-                        i = 0,
-                        len = 0,
-                        resp = false;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'userid') {
-                            userid = e.target.attributes[i].nodeValue.parseInt();
-                        } else if (e.target.attributes[i].nodeName === 'mname') {
-                            mname = e.target.attributes[i].nodeValue;
-                        }
-                    }
-
-                    resp = confirm("Are you sure you want to remove " + mname + " from your army?");
-                    if (resp === true) {
-                        caap.ajaxLink("army_member.php?action=delete&player_id=" + userid);
-                        this.deleteRecord(userid);
-                        session.setItem("ArmyDashUpdate", true);
-                        caap.updateDashboard(true);
-                    }
-                };
-
-                $j("span[id*='caap_removearmy_']", caap.caapTopObject).off('click', handler).on('click', handler);
-                handler = null;
-
-                session.setItem("ArmyDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in army.dashboard: " + err.stack);
-            return false;
-        }
-    };
+	army.dashboard = {
+		name: 'Army',
+		inst: 'Display your Army Members, the last time they leveled up',
+		records: 'army',
+		tableTemplate: {
+			colorF: function(r) {
+				if (schedule.since(r.change, config.getItem("ArmyAgeDays4", 28) * 86400)) {
+					return config.getItem("ArmyAgeDaysColor4", 'red');
+				} 
+				if (schedule.since(r.change, config.getItem("ArmyAgeDays3", 21) * 86400)) {
+					return config.getItem("ArmyAgeDaysColor3", 'darkorange');
+				} 
+				if (schedule.since(r.change, config.getItem("ArmyAgeDays2", 14) * 86400)) {
+					return config.getItem("ArmyAgeDaysColor2", 'gold');
+				} 
+				if (schedule.since(r.change, config.getItem("ArmyAgeDays1", 7) * 86400)) {
+					return config.getItem("ArmyAgeDaysColor1", 'greenyellow');
+				}
+				return config.getItem("ArmyAgeDaysColor0", 'green');
+			}
+		},
+		
+		tableEntries: [  
+			{name: 'User ID', color: 'blue', format: 'text',
+				valueF: function(r) {
+					return '<a href="' + caap.domain.altered + '/keep.php?casuser=' + r.userId +
+						'" onclick="ajaxLinkSend(\'globalContainer\', \'keep.php?casuser=' + r.userId +
+						'\'); return false;" style="text-decoration:none;font-size:9px;color:blue;">' +
+						r.userId + '</a>';
+			}},
+			{name: 'User',
+				valueF: function(r) {
+					return $u.hasContent(r.user) && ($u.isString(r.user) || r.user > 0) ?
+						"<a href='http://www.facebook.com/profile.php?id=" + r.userId + "'>" + r.user + "</a>" : '';
+			}},
+			{name: 'Name'},
+			{name: 'Level', value: 'lvl'},
+			{name: 'Change',
+				valueF: function(r) {
+					return $u.hasContent(r.change) && ($u.isString(r.change) || r.change > 0) ? $u.makeTime(r.change, "d-m-Y") : '';		
+			}},
+			{name: '&nbsp;', format: 'unsortable',
+				valueF: function(r) {
+					return '<a href="' + caap.domain.altered + '/army_member.php?action=delete&player_id=' + r.userId +
+						'" onclick="ajaxLinkSend(\'globalContainer\', \'army_member.php?action=delete&player_id=' + r.userId + '\'); return false;" class="ui-icon ui-icon-circle-close" style="text-decoration:none;font-size:9px;">X</a>';
+			}}
+		]
+	};
 
 }());

--- a/Chrome/unpacked/js/worker_battle.js
+++ b/Chrome/unpacked/js/worker_battle.js
@@ -285,20 +285,22 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 	// Calculate an a score based on level, army size, and previous experience for a battle record to pick the best target
 	battle.scoring = function(r, which) {
 		var w = battle[which],
-			defBonus = which == 'War' ? 'War' : w.invade ? r.army / stats.army.capped : 1; 
+			defBonus = which == 'War' ? 'War' : w.invade ? r.army / stats.army.capped : 1,
+			mult = battle.demisPointsToDo('left') ? 1 : battle.pointF(w.pointList, r[w.rank] - stats.rank[w.myRank]); 
 			
-		return battle.winChance(r, stats.bonus.api, defBonus) * battle.pointF(w.pointList, r[w.rank] - stats.rank[w.myRank]); 
+		return battle.winChance(r, stats.bonus.api, defBonus) * mult; 
 	};
 	
 	// Calculate an a score based on level, army size, and previous experience for a battle record to pick the best target
 	battle.filterF = function(arr, which) {
 		var	w = battle[which],
-			minRank = battle.minMaxRankF(w, 'min'),
+			minRank = battle.demisPointsToDo('left') ? 0 : battle.minMaxRankF(w, 'min'),
 			maxRank = battle.minMaxRankF(w, 'max'),
 			conqLevel = w.conq ? config.getItem('conquestLevels', 'Any').regexd(/(\d+)/, 0) : 0;
 			
 		return arr.filter( function(r) {
-			return r[w.rank] >= minRank && r[w.rank] <= maxRank && (!w.invade || r.army > 0) &&	(!w.conq || r.level >= conqLevel);
+			return r[w.rank] >= minRank && r[w.rank] <= maxRank && !r[w.lost] && (!w.invade || r.army > 0) &&
+				(!w.conq || r.level >= conqLevel);
 		});
 	};
 	
@@ -446,7 +448,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			Check ready to battle and what type of battle
 			\-------------------------------------------------------------------------------------*/
 			
-			if (!$u.isNumber(options) && whenBattle != 'Never') {
+			if (!$u.isNumber(options) || whenBattle != 'Never') {
 				switch (whenBattle) {
 				case 'Never':
 					return {action: false, mess: ''};
@@ -477,7 +479,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					if (options != 'monster') {
 						return false;
 					}
-					if (whenMonster !== 'Never' && monsterObject && !/the deathrune siege/i.test(monsterObject.name)) {
+					if (whenMonster !== 'Never' && $u.hasContent(monsterObject) && !/the deathrune siege/i.test(monsterObject.name)) {
 						return {action: false, mess: 'Waiting for monster'};
 					}
 				}
@@ -511,7 +513,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         try {
             var w = battle[which],
 				tempTxt,
-				result,
+				result = false,
 				targets = [],
 				targetRaid,
 				arenaTokens = 0, // Need to move this out of here eventually
@@ -523,34 +525,28 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 idList = $u.hasContent(w.idList) ? config.getList(w.idList, []) : [],
 				randomNum = Math.random() * 100,
 				valid,
-				demisLeft = battle.demisPointsToDo('left') || Math.floor(Math.random() * 5 + 1);
-
-			function freshmeat() {
-				targets = battle.records.filter( function(r) {
-					// Check timers/valid
-					return schedule.since(r[w.dead], 10 * 60) && schedule.since(r[w.chained], 0) && r[w.valid];
-				});
-				
-				targets = targets.concat(window[w.recon].records);
-				
-				targets = battle.filterF(targets, which);
-
-				targets.forEach( function(r) {
-					r.score = battle.scoring(r, which);
-				});
-				
-				if (!targets.length) {
-					if (schedule.check(w.reconDelay, 5 * 60)) { 
-						caap.ajaxLink(w.page);
-						return {mlog: 'Looking for ' + type + ' targets on ' + w.page};
+				demisLeft = battle.demisPointsToDo('left') || Math.floor(Math.random() * 5 + 1),
+				freshmeat = function() {
+					targets = battle.records.filter( function(r) {
+						// Check timers/valid
+						return schedule.since(r[w.dead], 10 * 60) && schedule.since(r[w.chained], 0) && r[w.valid];
+					});
+					targets = targets.concat(window[w.recon].records);
+					targets = battle.filterF(targets, which);
+					targets.forEach( function(r) {
+						r.score = battle.scoring(r, which);
+					});
+					if (!targets.length) {
+						if (schedule.check(w.reconDelay, 5 * 60)) { 
+							caap.ajaxLink(w.page);
+							return {mlog: 'Looking for ' + type + ' targets on ' + w.page};
+						}
+						return {action: false, mess: 'Recon for targets in ' + rejoinSecs};
 					}
-					return {action: false, mess: 'Recon for targets in ' + rejoinSecs};
-				}
-				
-				bR = targets.sort($u.sortBy(false, 'score')).pop();
-				state.setItem('wsave_battle_noWarning', true);
-				state.setItem('wsave_' + w.recon + '_noWarning', true);
-			}
+					bR = targets.sort($u.sortBy(false, 'score')).pop();
+					state.setItem('wsave_battle_noWarning', true);
+					state.setItem('wsave_' + w.recon + '_noWarning', true);
+				};
 			
 			if (!schedule.check(w.battleDelay)) {
 				return false;
@@ -569,14 +565,14 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 				cM = monster.getRecord(targetRaid);
 				
 				monster.lastClick = cM.link;
-				freshmeat();
+				result = freshmeat();
 				break;
 
 			case 'Freshmeat' :
 			/*-------------------------------------------------------------------------------------\
 				FRESHMEAT List targets, score, and hit best
 			\-------------------------------------------------------------------------------------*/
-				freshmeat();
+				result = freshmeat();
 				break;
 				
 			case 'User ID List' :
@@ -633,6 +629,10 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			default :
 				return {action: false, mwarn: 'Battle: invalid setting for Target Type: ' + config.getItem('targetType', 'Freshmeat')};
             }
+			
+			if ($u.isObject(result)) {
+				return result;
+			}
 
 			result = caap.navigate3($u.setContent(cM.link, w.page), w.linkF(bR.userId, demisLeft, cM.link), w.general);
 			if (result) {
@@ -722,7 +722,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 					con.log(2, 'Unable to parse win/loss from ' + caap.page + ', setting wait time for target ' + userId, resultsText, w);
 				}
 				battle.setRecord(bR);
-				recon.deleteRecord(userId);
+				window[w.recon].deleteRecord(userId);
 				return false;
 			}
 			
@@ -761,7 +761,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			}
 
 			battle.setRecord(bR);
-			recon.deleteRecord(bR.userId);
+			window[w.recon].deleteRecord(bR.userId);
         } catch (err) {
             con.error("ERROR in battle.readWinLoss: " + err.stack);
             return false;
@@ -928,266 +928,70 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             return '';
         }
     };
-
-    battle.dashboard = function(which) {
-        try {
-            /*-------------------------------------------------------------------------------------\
-            Next we build the HTML to be included into the 'caap_infoBattle' div. We set our
-            table and then build the header row.
-            \-------------------------------------------------------------------------------------*/
-			
-			which = which == 'Arena' ? which : 'Battle';
-            if (config.getItem('DBDisplay', '') === (which + ' Stats') && session.getItem(which + "DashUpdate", true)) {
-                var headers = ['UserId', 'Name', 'BR', 'WR', 'CR', 'Level', 'Army', 'Min Def', 'Max Def', 'Duel Win Chance', 'Invade', 'Duel', 'War', 'Points', '&nbsp;'],
-                    values = ['userId', 'name', 'rank', 'warRank', 'conqRank', 'level', 'army', 'minDef', 'maxDef', 'wc', 'invadeWon', 'duelWon', 'warWon', 'points'],
-                    pp = 0,
-                    i = 0,
-                    userIdLink = '',
-                    userIdLinkInstructions = '',
-                    len = 0,
-                    len1 = 0,
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    head = '',
-                    body = '',
-                    row = '',
-					arenaers = [],
-					winnerF = function(bR) {
-						return bR.duelWon > 0 && !bR.duelLost;
-					},
-					report = '',
-					types = ['duel', 'invade', 'war', 'conqInvade', 'conqDuel', 'gb'];
-
-				if (which == 'Arena') {
-					headers = ['UserId', 'Name', 'Points', 'Total', 'Duel', 'AR', 'Level', 'Army', '&nbsp;'];
-                    values = ['userId', 'name', 'arenaPoints', 'arenaTotal', 'duelWon', 'arenaRank', 'level', 'army'];
-					arenaers = battle.records.filter( function(bR) {
-						return bR.arenaRank;
-					});
-					
-					[1, 2, 3, 4, 5, 6, 7].forEach( function(rank) {
-						report += 'R' + rank + ': ';
-						var aRankArr = arenaers.filter( function(bR) {
-								return bR.arenaRank == rank;
-							}),
-							winnerSum = aRankArr.filter(winnerF).length;
-						report += winnerSum + '/' + aRankArr.length + ' ' + (winnerSum / aRankArr.length * 100).dp(1) + '% ';
-					});
-				}
-				
-                for (pp = 0; pp < headers.length; pp += 1) {
-                    switch (headers[pp]) {
-                    case 'UserId':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '16%'
-                        });
-                        break;
-                    case 'Name':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '20%'
-                        });
-                        break;
-                    case 'Invade':
-                    case 'Duel':
-                    case 'War':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '7%'
-                        });
-                        break;
-                    case 'CR':
-                    case 'BR':
-                    case 'WR':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '5%'
-                        });
-                        break;
-                    case '&nbsp;':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '1%'
-                        });
-                        break;
-                    default:
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '7%'
-                        });
-                    }
-                }
-
-                head = caap.makeTr(head);
-                for (i = 0, len = battle.records.length; i < len; i += 1) {
-                    row = "";
-                    for (pp = 0, len1 = values.length; pp < len1; pp += 1) {
-                        switch (values[pp]) {
-                        case 'userId':
-                            userIdLinkInstructions = "Clicking this link will take you to the user keep of " + battle.records[i][values[pp]];
-                            userIdLink = "keep.php?casuser=" + battle.records[i][values[pp]];
-                            data = {
-                                text: '<span id="caap_battle_' + i + '" title="' + userIdLinkInstructions + '" rlink="' + userIdLink +
-                                    '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + battle.records[i][values[pp]] + '</span>',
-                                color: 'blue',
-                                id: '',
-                                title: ''
-                            };
-
-                            row += caap.makeTd(data);
-                            break;
-                        case 'rank':
-                        case 'warRank':
-                        case 'conqRank':
-                            row += caap.makeTd({
-                                text: battle.records[i][values[pp]] < 0 ? '' : battle.records[i][values[pp]],
-                                color: '',
-                                id: '',
-                                title: battle.records[i][values[pp]] < 0 ? 'Unknown' : battle.ranks[values[pp]][battle.records[i][values[pp]]]
-                            });
-                            break;
-                        case 'wc':
-                            row += caap.makeTd({
-                                text: battle.winChance(battle.records[i], stats.bonus.api),
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                            break;
-                        case 'invadeWon':
-                            row += caap.makeTd({
-                                text: battle.records[i][values[pp]] + "/" + battle.records[i].invadeLost,
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                            break;
-                        case 'duelWon':
-                            row += caap.makeTd({
-                                text: battle.records[i][values[pp]] + "/" + battle.records[i].duelLost,
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                            break;
-                        case 'warWon':
-                            row += caap.makeTd({
-                                text: battle.records[i][values[pp]] + "/" + battle.records[i].warLost,
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                            break;
-                        case 'points':
-                            row += caap.makeTd({
-                                text:  types.reduce( function(p, c) {
-									return p + battle.records[i][c + 'Points'];
-								}, 0),
-                                color: '',
-                                id: '',
-                                title: types.map( function(e) {
-									return e.ucWords() + ': ' + battle.records[i][e + 'Points'];
-								}).join(', ')
-                            });
-                            break;
-                        default:
-                            row += caap.makeTd({
-                                text: battle.records[i][values[pp]],
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                        }
-                    }
-
-					userIdLinkInstructions = "Clicking this link will remove " + battle.records[i].name + "'s data from CAAP.";
-					data = {
-						text: '<span id="caap_battle_remove_' + battle.records[i].userId + '" title="' + userIdLinkInstructions 
-							+ '" userid="' + battle.records[i].userId + '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';" class="ui-icon ui-icon-circle-close">X</span>',
-						color: 'blue',
-						id: '',
-						title: ''
-					};
-
-					row += caap.makeTd(data);
-
-                    body += caap.makeTr(row);
-                }
-
-                $j("#caap_info" + which, caap.caapTopObject).html(
-                $j(caap.makeTable(which.toLowerCase(), head, body)).dataTable({
-                    "bAutoWidth": false,
-                    "bFilter": false,
-                    "bJQueryUI": false,
-                    "bInfo": false,
-                    "bLengthChange": false,
-                    "bPaginate": false,
-                    "bProcessing": false,
-                    "bStateSave": true,
-                    "bSortClasses": false,
-                    "aoColumnDefs": [{
-                        "bSortable": false,
-                        "aTargets": [headers.length - 1]
-                    }]
-					}));
-				$j("#caap_info" + which, caap.caapTopObject).prepend(report);
-				
-                $j("span[id*='caap_battle_']", caap.caapTopObject).click(function(e) {
-					i = 0;
-					len = 0;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'rlink') {
-							caap.ajaxLink(e.target.attributes[i].nodeValue);
-							return true;
-                        }
-                    }
-
-                });
-
-                $j("span[id^='caap_battle_remove_']", caap.caapTopObject).click(function(e) {
-                    i = 0;
-                    len = 0;
-						
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'userid') {
-                            battle.deleteRecord(e.target.attributes[i].value);
-                        }
-                    }
-                });
-
-                session.setItem(which + "DashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in battle.dashboard: " + err.stack, which);
-            return false;
-        }
-    };
+	
+	battle.dashboard = {
+		name: 'Battle Stats',
+		inst: 'Display your Battle history statistics, who you fought and if you won or lost',
+		records: 'battle',
+		buttons: ['clear'],
+		tableEntries: [
+			{name: 'User ID', color: 'blue', format: 'text',
+				valueF: function(r) {
+					return '<a href="' + caap.domain.altered + '/keep.php?casuser=' + r.userId +
+						'" onclick="ajaxLinkSend(\'globalContainer\', \'keep.php?casuser=' + r.userId +
+						'\'); return false;" style="text-decoration:none;font-size:9px;color:blue;">' +
+						r.userId + '</a>';
+			}},
+			{name: 'Name'},
+			{name: 'BR', value: 'rank', format: 'nonnegative',
+				titleF: function(r) {
+					return 'Battle Rank ' + r.rank < 0 ? 'Unknown' : battle.ranks.rank[r.rank];
+			}},
+			{name: 'WR', value: 'warRank', format: 'nonnegative',
+				titleF: function(r) {
+					return 'War Rank ' + r.warRank < 0 ? 'Unknown' : battle.ranks.warRank[r.warRank];
+			}},
+			{name: 'FR', value: 'festRank', format: 'nonnegative',
+				titleF: function(r) {
+					return 'Festival Rank ' + r.festRank < 0 ? 'Unknown' : battle.ranks.festRank[r.festRank];
+			}},
+			{name: 'CR', value: 'conqRank', format: 'nonnegative',
+				titleF: function(r) {
+					return 'Conquest Rank ' + r.conqRank < 0 ? 'Unknown' : battle.ranks.conqRank[r.conqRank];
+			}},
+			{name: 'Level'},
+			{name: 'Army'},
+			{name: 'Min Def', value: 'minDef'},
+			{name: 'Max Def', value: 'maxDef'},
+			{name: 'Duel Win Chance', 
+				valueF: function(r) {
+					return  battle.winChance(r, stats.bonus.api);
+			}},
+			{name: 'Invade', 
+				valueF: function(r) {
+					return  r.invadeWon + "/" + r.invadeLost;
+			}},
+			{name: 'Duel', 
+				valueF: function(r) {
+					return  r.duelWon + "/" + r.duelLost;
+			}},
+			{name: 'War', 
+				valueF: function(r) {
+					return  r.warWon + "/" + r.warLost;
+			}},
+			{name: 'Points', 
+				valueF: function(r) {
+					return ['duel', 'invade', 'war', 'fest', 'conqInvade', 'conqDuel', 'gb'].reduce( function(p, c) {
+							return p + r[c + 'Points'];
+						}, 0);
+				},
+				titleF: function(r) {
+					return ['duel', 'invade', 'war', 'fest', 'conqInvade', 'conqDuel', 'gb'].map( function(e) {
+							return e.ucWords() + ': ' + r[e + 'Points'];
+						}).join(', ');
+			}},
+			{name: 'name', type: 'remove'}
+		]
+	};
 
 }());

--- a/Chrome/unpacked/js/worker_caap.js
+++ b/Chrome/unpacked/js/worker_caap.js
@@ -79,7 +79,6 @@ schedule,gifting,state,army, general,session,monster,feed */
         if (caap.doCTAs()) {
             return true;
         }
-        caap.updateDashboard();
         return true;
     };
 

--- a/Chrome/unpacked/js/worker_chores.js
+++ b/Chrome/unpacked/js/worker_chores.js
@@ -533,6 +533,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 alchemyWhiteListInstructions = "List of recipes to combine. Will not combine recipes with ingredients that can be used in multiple recipes, like " + state.getItem('alchemydupNames', ['Battle Hearts']).join(', ') + 
 					". Leave blank to combine any other recipes. Not case sensitive.",
                 alchemyBlackListInstructions = "List of recipes not to combine. " + "Not case sensitive.",
+                itemInvInst = "Inventory all items. Uses local storage space and not used by CAAP except to display the Item dashboard.",
                 potionsInstructions0 = "Enable or disable the consumption " + "of energy and stamina potions.",
                 potionsInstructions1 = "Number of stamina potions at which to " + "begin consuming.",
                 potionsInstructions2 = "Number of stamina potions to keep.",
@@ -541,7 +542,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
                 potionsInstructions5 = "Do not consume potions if the " + "experience points to the next level are within this value.",
                 htmlCode = '';
 
-            htmlCode += caap.startToggle('Item', 'ITEM');
+            htmlCode += caap.startToggle('Item', 'ITEMS');
             htmlCode += caap.makeCheckTR('Potions', 'potions', false, potionsInstructions0);
             htmlCode += caap.display.start('potions');
             htmlCode += caap.makeNumberFormTR("Spend Stamina At", 'staminaPotionsSpendOver', potionsInstructions1, 30, '', '', true, false);
@@ -565,6 +566,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
             htmlCode += caap.makeTD("Kobo Item Black List",true);
             htmlCode += caap.makeTextBox('kobo_blacklist', koboBlackListInstructions, '', '');
             htmlCode += caap.display.end('kobo');
+            htmlCode += caap.makeCheckTR('Inventory Items', 'itemIventory', false, itemInvInst);
             htmlCode += caap.endToggle;
             return htmlCode;
         } catch (err) {

--- a/Chrome/unpacked/js/worker_essence.js
+++ b/Chrome/unpacked/js/worker_essence.js
@@ -27,35 +27,6 @@ regexp: true, eqeq: true, newcap: true, forin: false */
         };
     };
 
-    essence.clear = function() {
-        try {
-            essence.records = [];
-            state.setItem('wsave_essence', true);
-            session.setItem("essenceDashUpdate", true);
-            return true;
-        } catch (err) {
-            con.error("ERROR in essence.clear: " + err);
-            return false;
-        }
-    };
-
-    essence.rescan = function() {
-        try {
-            essence.records.forEach( function(e) {
-                e.lastCheck = Date.now();
-				['attack', 'defense', 'damage', 'health'].forEach( function(a) {
-					e[a] = -1;
-				});
-            });
-            state.setItem('wsave_essence', true);
-            session.setItem("essenceDashUpdate", true);
-            return true;
-        } catch (err) {
-            con.error("ERROR in essence.clear: " + err);
-            return false;
-        }
-    };
-
     essence.checkResults = function(page) {
         try {
 			var storageDivs, guildCapsules, eR;
@@ -108,149 +79,6 @@ regexp: true, eqeq: true, newcap: true, forin: false */
         }
     };
 	
-    essence.dashboard = function() {
-        try {
-            /*-------------------------------------------------------------------------------------\
-            Next we build the HTML to be included into the 'caap_infoGuilds' div. We set our
-            table and then build the header row.
-            \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Guild Essence' && session.getItem("essenceDashUpdate", true)) {
-                var headers = ['Name', 'Attack', 'Defense', 'Damage', 'Health'],
-                    values = ['name', 'attack', 'defense', 'damage', 'health'],
-                    pp = 0,
-                    i = 0,
-                    userIdLink = '',
-                    userIdLinkInstructions = '',
-                    len = 0,
-                    len1 = 0,
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    head = '',
-                    body = '',
-                    row = '';
-
-                for (pp = 0; pp < headers.length; pp += 1) {
-                    switch (headers[pp]) {
-                    case 'Name':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '30%'
-                        });
-                        break;
-                    case 'attack':
-                    case 'defense':
-                    case 'damage':
-                    case 'health':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '10%'
-                        });
-                        break;
-                    default:
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '7%'
-                        });
-                    }
-                }
-
-                head = caap.makeTr(head);
-                for (i = 0, len = essence.records.length; i < len; i += 1) {
-                    row = "";
-                    for (pp = 0, len1 = values.length; pp < len1; pp += 1) {
-                        switch (values[pp]) {
-                        case 'name':
-                            userIdLinkInstructions = "Clicking this link will take you to the guild keep of " + essence.records[i][values[pp]];
-                            userIdLink = "guild_conquest_market.php?guild_id=" + essence.records[i].guildId;
-                            data = {
-                                text: '<span id="caap_Guilds_' + i + '" title="' + userIdLinkInstructions + '" rlink="' + userIdLink +
-                                    '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + essence.records[i][values[pp]] + '</span>',
-                                color: 'blue',
-                                id: '',
-                                title: ''
-                            };
-
-                            row += caap.makeTd(data);
-                            break;
-                        case 'attack':
-                        case 'defense':
-                        case 'damage':
-                        case 'health':
-							row += caap.makeTd({
-                                text: essence.records[i][values[pp]],
-                                color: essence.records[i][values[pp]] > 0 ? 'green' : 'black'			,
-                                id: '',
-                                title: ''
-                            });
-                            break;
-                        default:
-                            row += caap.makeTd({
-                                text: essence.records[i][values[pp]],
-                                color: '',
-                                id: '',
-                                title: ''
-                            });
-                        }
-                    }
-
-                    body += caap.makeTr(row);
-                }
-
-                $j("#caap_infoGuilds", caap.caapTopObject).html(
-                $j(caap.makeTable("Guilds", head, body)).dataTable({
-                    "bAutoWidth": false,
-                    "bFilter": false,
-                    "bJQueryUI": false,
-                    "bInfo": false,
-                    "bLengthChange": false,
-                    "bPaginate": false,
-                    "bProcessing": false,
-                    "bStateSave": true,
-                    "bSortClasses": false
-                }));
-
-                $j("span[id*='caap_Guilds_']", caap.caapTopObject).click(function(e) {
-                    var visitUserIdLink = {
-                        rlink: '',
-                        arlink: ''
-                    },
-                    i = 0,
-                    len = 0;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'rlink') {
-                            visitUserIdLink.rlink = e.target.attributes[i].nodeValue;
-                            visitUserIdLink.arlink = visitUserIdLink.rlink;
-                        }
-                    }
-
-                    caap.ajaxLink(visitUserIdLink.arlink);
-                });
-
-                session.setItem("essenceDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in essence.dashboard: " + err);
-            return false;
-        }
-    };
-
 	worker.addPageCheck({page : 'trade_market', config: 'EssenceScanCheck'});
 	
 	worker.addAction({worker : 'essence', priority : -2600, description : 'Scout Guild Essence'});
@@ -382,5 +210,36 @@ regexp: true, eqeq: true, newcap: true, forin: false */
             return '';
         }
     };
+	
+	essence.dashboard = {
+		name: 'Essence Stats',
+		inst: 'Display Essence storage space for Guilds that have been scouted',
+		records: 'essence',
+		buttons: ['clear',
+			{name: 'Rescan Essence',
+				func: function() {
+					essence.records.forEach( function(e) {
+						e.lastCheck = Date.now();
+						['attack', 'defense', 'damage', 'health'].forEach( function(a) {
+							e[a] = -1;
+						});
+					});
+					essence.save('update');
+			}}
+		],
+		tableEntries: [
+			{name: 'User ID', color: 'blue', format: 'text',
+				valueF: function(r) {
+					return '<a href="' + caap.domain.altered + '/guild_conquest_market.php?guild_id=' + r.guildId +
+						'" onclick="ajaxLinkSend(\'globalContainer\', \'guild_conquest_market.php?guild_id=' + r.guildId +
+						'\'); return false;" style="text-decoration:none;font-size:9px;">' + r.name + '</a>';
+			}},
+			{name: 'Attack', format: 'nonnegative'},
+			{name: 'Defense', format: 'nonnegative'},
+			{name: 'Damage', format: 'nonnegative'},
+			{name: 'Health', format: 'nonnegative'},
+			{name: 'name', type: 'remove'}
+		]
+	};
 	
 }());

--- a/Chrome/unpacked/js/worker_feed.js
+++ b/Chrome/unpacked/js/worker_feed.js
@@ -1,7 +1,7 @@
 /*jslint white: true, browser: true, devel: true,
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global $j,$u,caap,config,con,feed:true,schedule,stats,state,worker,
+/*global $j,$u,caap,config,con,feed:true,schedule,stats,state,worker,ignoreJSLintError,
 chores,town,general,session,monster:true */
 /*jslint maxlen: 256 */
 
@@ -17,6 +17,10 @@ chores,town,general,session,monster:true */
 	
     feed.init = function() {
 		try {
+			// Fill out dashboard with monster dash entries
+			feed.dashboard = $j.extend(true, {}, monster.dashboard, feed.dashboard);
+			feed.dashboard.tableEntries[2] = {name: 'Score', value: 'score', format: 'number'};
+				
 			if (!config.getItem('enableMonsterFinder', false)) {
 				return false;
 			}
@@ -143,6 +147,7 @@ chores,town,general,session,monster:true */
 						return false;
 					}
 					cM.joinConditions = conditions;
+					cM.jFullC = item;
 					matched = feed.scoring(cM);
 					return true;
 				}
@@ -252,6 +257,10 @@ chores,town,general,session,monster:true */
 					} else {
 						link += ",clickimg:battle_enter_battle.gif";
 					}
+				}
+				
+				if (general.select('MonsterGeneral')) {
+					return true;
 				}
 			
 				con.log(1, 'Joining ' + tR.name, tR, link);
@@ -472,6 +481,10 @@ chores,town,general,session,monster:true */
 				achleft = 0,
 				conq = cM.link.hasIndexOf('guildv2_battle_monster'),
 				achrecords = stats.achievements.monster;
+
+			ignoreJSLintError(filterok, userid, life, t2k, dp, sameundermax, undermax, targetpart, parts, time, monstername, damagemod, rogue,
+				warlock, cleric, warrior, mage, ranger, levelup, energy, atmaxenergy, atmaxstamina, exp, needpic, needrecipe, userdamage, keep,
+				guild, achleft);
 				
 			killed = killed ? achrecords[killed] : Object.keys(achrecords).reduce(function(previous, current) {
 				return previous || (current.hasIndexOf(cM.monster) && !current.match(/'s/) ? achrecords[current] : 0);
@@ -543,15 +556,19 @@ chores,town,general,session,monster:true */
 		}
 	};
 
-    feed.dashboard = function() {
-		try {
-			monster.dashboardCommon('Feed');
-		} catch (err) {
-			con.error("ERROR in feed.dashboard: " + err.stack);
-			return false;
-		}
+	feed.dashboard = {
+		name: 'Feed',
+		inst: 'Display the monsters that are public or from your Guild Priority list',
+		filterF: function(cM) {
+			return cM.state == 'Join';
+		},
+		buttons: [{name: 'Clear Feed',
+			func: function() {
+				monster.fullReview('Feed');
+			}
+		}]
 	};
-
+	
     feed.menu = function() {
 		try {
 			var htmlCode = '',

--- a/Chrome/unpacked/js/worker_general.js
+++ b/Chrome/unpacked/js/worker_general.js
@@ -25,16 +25,16 @@ schedule,gifting,state,stats,general,session,monster,worker,guild_monster */
             pct : 0,
             last : 0,
             special : '',
-            atk : 0,
-            def : 0,
-            api : 0,
-            dpi : 0,
-            mpi : 0,
-            eatk : 0,
-            edef : 0,
-            eapi : 0,
-            edpi : 0,
-            empi : 0,
+            atk : -1,
+            def : -1,
+            api : -1,
+            dpi : -1,
+            mpi : -1,
+            eatk : -1,
+            edef : -1,
+            eapi : -1,
+            edpi : -1,
+            empi : -1,
             energy : 0,
             stamina : 0,
             attackItemBonus : 0,
@@ -340,7 +340,8 @@ schedule,gifting,state,stats,general,session,monster,worker,guild_monster */
 				gR = general.getRecordByField('value', tNum.numberOnly());
 				
 				text = $j('#loadout_general img').attr('src');
-				gR.general = $u.hasContent(text) ? general.getRecordByField('img', text.regex(/.*\/(\w+\.\w+)/)).name : 'Use Current';
+				gR.general = $u.hasContent(text) ? general.getRecordByField('img', text.regex(/.*\/(\w+\.\w+)/)).name :
+					$u.setContent(gR.general, 'Use Current');
 				
 				gR.powers = $j.makeArray($j('#loadout_powers').find('img').map(function() {
 					return $j(this).attr('src').regex(/(\w+\.\w+)$/); 
@@ -932,7 +933,8 @@ schedule,gifting,state,stats,general,session,monster,worker,guild_monster */
 					
 					con.log(2, 'Houston, we have a problem. Loadout ' + g.nameBeforeReset + ' appears to be reset. Attempting to rebuild');
 					if (caap.page != 'player_loadouts' || !caap.clickUrl.hasIndexOf('loadout=' + g.value)) {
-						caap.ajaxLink('player_loadouts.php?item_id=' + general.getRecordVal(g.general, 'item', false) + '&item_category=1&action=select_loadout_general&selection=1&loadout=' + g.value);
+						caap.ajaxLink('player_loadouts.php?item_id=' + general.getRecordVal(g.general, 'item', false) + '&item_category=' +
+						general.getRecordVal(g.general, 'itype', false) + '&action=select_loadout_general&selection=1&loadout=' + g.value);
 						click = true;
 						return true;
 					}
@@ -1069,164 +1071,30 @@ schedule,gifting,state,stats,general,session,monster,worker,guild_monster */
         }
     };
 
-    general.dashboard = function () {
-        try {
-            /*-------------------------------------------------------------------------------------\
-                Next we build the HTML to be included into the 'caap_generalsStats' div. We set our
-                table and then build the header row.
-                \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Generals Stats' && session.getItem("GeneralsDashUpdate", true)) {
-                var headers = ['General', 'Lvl', 'Atk', 'Def', 'API', 'DPI', 'MPI', 'EAtk', 'EDef', 'EAPI', 'EDPI', 'EMPI', 'Special'],
-                    values = ['name', 'lvl', 'atk', 'def', 'api', 'dpi', 'mpi', 'eatk', 'edef', 'eapi', 'edpi', 'empi', 'special'],
-                    calc = 0,
-                    pp = 0,
-                    link = '',
-                    instructions = '',
-                    it = 0,
-                    len = 0,
-                    len1 = 0,
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    header = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: ''
-                    },
-                    handler = null,
-                    head = '',
-                    body = '',
-                    row = '';
-
-                for (pp = 0, len = headers.length; pp < len; pp += 1) {
-                    header = {
-                        text: headers[pp],
-                        color: '',
-                        id: '',
-                        title: '',
-                        width: '7%'
-                    };
-
-                    switch (headers[pp]) {
-                        case 'General':
-                            header.width = '13%';
-                            break;
-                        case 'Lvl':
-                        case 'Atk':
-                        case 'Def':
-                        case 'API':
-                        case 'DPI':
-                        case 'MPI':
-                            header.width = '5.5%';
-                            break;
-                        case 'Special':
-                            header.width = '19%';
-                            break;
-                        default:
-							break;
-                    }
-
-                    head += caap.makeTh(header);
-                }
-
-                head = caap.makeTr(head);
-                for (it = 0, len = general.records.length; it < len; it += 1) {
-                    row = "";
-                    for (pp = 0, len1 = values.length; pp < len1; pp += 1) {
-                        if (values[pp] === 'name') {
-                            link = "generals.php";
-                            instructions = "Clicking this link will change General to " + general.records[it].name;
-                            data = {
-                                text: '<span id="caap_general_' + it + '" title="' + instructions + '" mname="' + general.records[it].name + '" rlink="' + link + '" itype="' + general.records[it].itype + '" item="' + general.records[it].item +
-                                    '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + general.records[it].name + '</span>',
-                                color: 'blue',
-                                id: '',
-                                title: ''
-                            };
-
-                            row += caap.makeTd(data);
-                        } else {
-                            calc = general.getRecordVal(general.records[it].name,[values[pp]]) || '';
-                            row += caap.makeTd({
-                                text: $u.setContent(calc, ''),
-                                color: '',
-                                title: ''
-                            });
-                        }
-                    }
-
-                    body += caap.makeTr(row);
-                }
-
-                $j("#caap_generalsStats", caap.caapTopObject).html(
-                $j(caap.makeTable("general", head, body)).dataTable({
-                    "bAutoWidth": false,
-                    "bFilter": false,
-                    "bJQueryUI": false,
-                    "bInfo": false,
-                    "bLengthChange": false,
-                    "bPaginate": false,
-                    "bProcessing": false,
-                    "bStateSave": true,
-                    "bSortClasses": false,
-                    "aoColumnDefs": [{
-                        "bSortable": false,
-                        "aTargets": [12]
-                    }]
-                }));
-
-                handler = function (e) {
-                    var changeLink = {
-							mname: '',
-							rlink: '',
-							itype: '',
-							item: ''
-						},
-						i = 0,
-                        len2 = 0,
-                        gen = {},
-                        page = session.getItem("page", "");
-
-                    for (i = 0, len2 = e.target.attributes.length; i < len2; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'mname') {
-                            changeLink.mname = e.target.attributes[i].value;
-                        } else if (e.target.attributes[i].nodeName === 'rlink') {
-                            changeLink.rlink = e.target.attributes[i].value;
-                        } else if (e.target.attributes[i].nodeName === 'itype') {
-                            gen.itype = changeLink.itype = e.target.attributes[i].value.parseInt();
-                        } else if (e.target.attributes[i].nodeName === 'item') {
-                            gen.item = changeLink.item = e.target.attributes[i].value.parseInt();
-                        }
-                    }
-
-                    if ($u.hasContent(changeLink.rlink)) {
-                        caap.ajaxLoadIcon.css("display", "block");
-                        if (page === "generals") {
-                            caap.ajaxLink(changeLink.rlink + "?itype=" + gen.itype + "&item=" + gen.item);
-                        } else {
-                            general.quickSwitch = true;
-                            caap.ajaxLoad(changeLink.rlink, gen, "#equippedGeneralContainer", "#equippedGeneralContainer", page);
-                        }
-                    }
-                };
-
-                $j("span[id*='caap_general_']", caap.caapTopObject).off('click', handler).click(handler);
-
-                session.setItem("GeneralsDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in general.dashboard: " + err.stack);
-            return false;
-        }
-    };
+	general.dashboard = {
+		name: 'Generals',
+		inst: 'Display information about your Generals',
+		records: 'general',
+		buttons: ['clear'],
+		tableTemplate: { width: '5.5%', format: 'nonnegative' },
+		
+		tableEntries: [ 
+			{name: 'General', value: 'name', color: 'blue', width: '13%', format: 'text',
+				valueF: function(r) {
+					return '<div class="hotSwapGenName" onclick="doHotSwapGeneral(\'' + r.item + '\', \'' + r.itype + '\', false);">' + 
+						r.name + '</div>';
+			}},
+			{name: 'Lvl',
+				valueF: function(r) {
+					return r.lvl + '/' + r.lvlmax;
+			}},
+			{name: 'Atk'},
+			{name: 'Def'},
+			{name: 'EAPI'},
+			{name: 'EDPI'},
+			{name: 'EMPI'},
+			{name: 'Special', width: '46.5%'}
+		]
+	};
 
 }());

--- a/Chrome/unpacked/js/worker_guild_monster.js
+++ b/Chrome/unpacked/js/worker_guild_monster.js
@@ -1,8 +1,8 @@
-/*jslint white: true, browser: true, devel: true, undef: true,
+/*jslint white: true, browser: true, devel: true, 
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global window,escape,jQuery,$j,rison,utility,
-$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,gm,
+/*global window,escape,stats,$j,rison,utility,
+$u,chrome,worker,self,caap,config,con,gm,
 schedule,gifting,state,army, general,session,monster:true,guild_monster: true */
 /*jslint maxlen: 256 */
 
@@ -417,7 +417,7 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster: true */
                 return true;
             }
 
-            schedule.setItem("guildMonsterReview", (gm ? gm.getItem('guildMonsterReviewMins', 60, hiddenVar) : 60) * 60, 300);
+            schedule.setItem("guildMonsterReview", (gm ? gm.getItem('guildMonsterReviewMins', 60) : 60) * 60, 300);
             state.setItem('guildMonsterBattlesRefresh', true);
             state.setItem('guildMonsterBattlesReview', false);
             state.setItem('guildMonsterReviewSlot', 0);
@@ -442,7 +442,6 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster: true */
                 if (state.getItem('targetFrombattle_monster', '') || state.getItem('targetFromraid', '')) {
                     return true;
                 }
-                var WhenBattle = config.getItem("WhenBattle", 'Never');
             }
 
             return false;
@@ -901,21 +900,6 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster: true */
             return false;
         } catch (err) {
             con.error("ERROR in guild_monster.deleteItem: " + err);
-            return false;
-        }
-    };
-
-    guild_monster.clear = function() {
-        try {
-            con.log(1, "guild_monster.clear");
-            guild_monster.records = [];
-            guild_monster.save();
-            state.setItem('staminaGuildMonster', 0);
-            state.setItem('targetGuildMonster', {});
-            session.setItem("GuildMonsterDashUpdate", true);
-            return true;
-        } catch (err) {
-            con.error("ERROR in guild_monster.clear: " + err);
             return false;
         }
     };
@@ -1413,142 +1397,40 @@ schedule,gifting,state,army, general,session,monster:true,guild_monster: true */
         }
     };
 
-    guild_monster.dashboard = function() {
-        try {
-            /*-------------------------------------------------------------------------------------\
-                Next we build the HTML to be included into the 'caap_guildMonster' div. We set our
-                table and then build the header row.
-                \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Guild Monster' && session.getItem("GuildMonsterDashUpdate", true)) {
-                var color = '',
-                    headers = ['Slot', 'Name', 'Damage', 'Damage%', 'My Status', 'TimeLeft', 'Status', 'Link', '&nbsp;'],
-                    values = ['slot', 'name', 'damage', 'enemyHealth', 'myStatus', 'ticker', 'state'],
-                    pp = 0,
-                    i = 0,
-                    len = 0,
-                    len1 = 0,
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    handler = null,
-                    head = '',
-                    body = '',
-                    row = '';
-
-                for (pp = 0; pp < headers.length; pp += 1) {
-                    head += caap.makeTh({
-                        text: headers[pp],
-                        color: '',
-                        id: '',
-                        title: '',
-                        width: ''
-                    });
-                }
-
-                head = caap.makeTr(head);
-                for (i = 0, len = guild_monster.records.length; i < len; i += 1) {
-                    row = "";
-                    for (pp = 0, len1 = values.length; pp < len1; pp += 1) {
-                        switch (values[pp]) {
-                        case 'name':
-                            data = {
-                                text: '<span id="caap_guildmonster_' + pp + '" title="Clicking this link will take you to (' + guild_monster.records[i].slot + ') ' + guild_monster.records[i].name + '" mname="' + guild_monster.records[i].slot +
-                                    '" rlink="guild_battle_monster.php?twt2=' + guild_monster.info[guild_monster.records[i].name].twt2 + '&guild_id=' + guild_monster.records[i].guildId + '&slot=' + guild_monster.records[i].slot +
-                                    '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + guild_monster.records[i].name + '</span>',
-                                color: guild_monster.records[i].color,
-                                id: '',
-                                title: ''
-                            };
-
-                            row += caap.makeTd(data);
-
-                            break;
-                        case 'ticker':
-                            row += caap.makeTd({
-                                text: $u.hasContent(guild_monster.records[i][values[pp]]) ? guild_monster.records[i][values[pp]].regex(/(\d+:\d+):\d+/) : '',
-                                color: guild_monster.records[i].color,
-                                id: '',
-                                title: ''
-                            });
-
-                            break;
-                        default:
-                            row += caap.makeTd({
-                                text: $u.hasContent(guild_monster.records[i][values[pp]]) ? guild_monster.records[i][values[pp]] : '',
-                                color: guild_monster.records[i].color,
-                                id: '',
-                                title: ''
-                            });
-                        }
-                    }
-
-                    data = {
-                        text: '<a href="' + caap.domain.altered + '/guild_battle_monster.php?twt2=' + guild_monster.info[guild_monster.records[i].name].twt2 + '&guild_id=' + guild_monster.records[i].guildId +
-                            '&action=doObjective&slot=' + guild_monster.records[i].slot + '&ref=nf">Link</a>',
-                        color: 'blue',
-                        id: '',
-                        title: 'This is a siege link.'
-                    };
-
-                    row += caap.makeTd(data);
-
-                    if ($u.hasContent(guild_monster.records[i].conditions) && guild_monster.records[i].conditions !== 'none') {
-                        data = {
-                            text: '<span title="User Set Conditions: ' + guild_monster.records[i].conditions + '" class="ui-icon ui-icon-info">i</span>',
-                            color: guild_monster.records[i].color,
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-                    } else {
-                        row += caap.makeTd({
-                            text: '',
-                            color: color,
-                            id: '',
-                            title: ''
-                        });
-                    }
-
-                    body += caap.makeTr(row);
-                }
-
-                $j("#caap_guildMonster", caap.caapTopObject).html(caap.makeTable("guild_monster", head, body));
-
-                handler = function(e) {
-                    var visitMonsterLink = {
-                        mname: '',
-                        arlink: ''
-                    },
-                    i = 0,
-                        len = 0;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'mname') {
-                            visitMonsterLink.mname = e.target.attributes[i].nodeValue;
-                        } else if (e.target.attributes[i].nodeName === 'rlink') {
-                            visitMonsterLink.arlink = e.target.attributes[i].nodeValue;
-                        }
-                    }
-
-                    caap.ajaxLink(visitMonsterLink.arlink);
-                };
-
-                $j("span[id*='caap_guildmonster_']", caap.caapTopObject).off('click', handler).on('click', handler);
-                handler = null;
-
-                session.setItem("GuildMonsterDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in guild_monster.dashboard: " + err);
-            return false;
-        }
-    };
+	guild_monster.dashboard = {		
+		name: 'Guild Monsters',
+		inst: 'Display your Guild Monsters',
+		records: 'guild_monster',
+		buttons: [{name: 'Refresh Monster List',
+			func: function() {
+				state.setItem('staminaGuildMonster', 0);
+				state.setItem('targetGuildMonster', {});
+				guild_monster.save('update');
+				schedule.setItem("guildMonsterReview", 0);
+			}
+		}],
+		tableTemplate: {
+			colorF: function(cM) {
+				return cM.color;
+		}},
+		tableEntries: [
+			{name: 'Name', color: 'blue', 
+				valueF: function(cM) {
+					var link = '"guild_battle_monster.php?twt2=' + guild_monster.info[cM.name].twt2 + '&guild_id=' + cM.guildId +
+						'&slot=' + cM.slot;
+					return '<a href="' + caap.domain.altered + '/' + link + '" onclick="ajaxLinkSend(\'globalContainer\', \'' + link +
+						'\'); ' + ' return false;" style="text-decoration:none;font-size:9px;">' + cM.name + '</a>';
+			}},
+			{name: 'Damage'},
+			{name: 'Damage%', value: 'enemyHealth'},
+			{name: 'My Status', value: 'myStatus'},
+			{name: 'TimeLeft', format: 'time',
+				valueF: function(r) {
+					return $u.hasContent(r.ticker) ? r.ticker.regex(/(\d+:\d+):\d+/) : '';
+			}},
+			{name: 'Status', value: 'state'},
+			{name: 'name', type: 'remove'}
+		]
+	};
 
 }());

--- a/Chrome/unpacked/js/worker_monster.js
+++ b/Chrome/unpacked/js/worker_monster.js
@@ -1049,7 +1049,7 @@ config,con,gm,schedule,state,general,session,monster:true */
                 }
 				// Skipping raids until fixed
                 if (cM.link.hasIndexOf('raid.php')) {
-                    continue;
+                    return false;
                 }
                 if (cM.color === 'grey' && cM.life == 100) {
                     cM.life = 0;

--- a/Chrome/unpacked/js/worker_monster.js
+++ b/Chrome/unpacked/js/worker_monster.js
@@ -1,7 +1,7 @@
 /*jslint white: true, browser: true, devel: true, 
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global window,stats,$j,battle,$u,worker,feed,caap,statsFunc,
+/*global window,stats,$j,battle,$u,worker,feed,caap,statsFunc,ignoreJSLintError,
 config,con,gm,schedule,state,general,session,monster:true */
 /*jslint maxlen: 256 */
 
@@ -105,6 +105,8 @@ config,con,gm,schedule,state,general,session,monster:true */
     monster.checkResults_list = function (page, resultsText, ajax, slice) {
 	/*jslint unparam: true */
         try {
+			ignoreJSLintError(resultsText, ajax);
+			
 			var lastClick = $u.setContent(monster.lastClick, session.getItem('clickUrl','')),
 				pageURL = session.getItem('clickUrl', ''),
 				mR = {},
@@ -181,31 +183,19 @@ config,con,gm,schedule,state,general,session,monster:true */
 				mR.listReviewed = now;
 				
 				switch ($u.setContent($j(which.button, this).attr("src"), '').regex(/_btn_(\w*)/)) {
-				case 2:
-					mR.state = 'Collect';
-					break;
-				case 3:
-					mR.state = 'Attack';
-					break;
-				case 4:
-					feed.checkDeath(mR);
-					mR.state = 'Dead';
-					break;
-				case 'collect':
-					feed.checkDeath(mR);
-					mR.state = mR.state == 'Attack' ? 'Dead or fled' : $u.setContent(mR.state, 'Dead or fled');
-					break;
-				case 'atk':
-					mR.state = $u.setContent(mR.state, 'Attack');
-					break;
-				case 'join':
-				case 'joinmonster':
-					mR.state = $u.setContent(mR.state, 'Join');
-					break;
-				default:
-					con.warn("Unknown engageButtonName state for " + mR.name);
-					break;
+				case 2:				mR.state = 'Collect';									 		break;
+				case 3:				mR.state = 'Attack';											break;
+				case 4:				feed.checkDeath(mR);			mR.state = 'Dead';				break;
+				case 'view':		mR.state = 'Dead';												break;
+				case 'atk':			mR.state = $u.setContent(mR.state, 'Attack');					break;
+				case 'join':	
+				case 'joinmonster':	mR.state = $u.setContent(mR.state, 'Join');						break;
+				case 'collect':		feed.checkDeath(mR);
+									mR.state = mR.state == 'Attack' ? 'Dead or fled' : $u.setContent(mR.state, 'Dead or fled');
+									break;
+				default:			con.warn("Unknown engageButtonName state for " + mR.name);		break;
 				}
+				
 				mR.color = ['Dead', 'Collect', 'Dead or fled'].hasIndexOf(mR.state) ? 'grey' : mR.state == 'Attack' && mR.color == 'grey' ? 'black' : mR.color;
 				if (publicList && !feed.joinable(mR)) {
 					return true;
@@ -350,9 +340,9 @@ config,con,gm,schedule,state,general,session,monster:true */
 			} else {
 				tempDiv = $j("div[style*='monster_health_back.jpg']", slice);
 			}
-			tempText = tempDiv.text().trim();
+			tempText = tempDiv.text().trim().innerTrim();
 			if (tempText.toLowerCase().hasIndexOf('life') || tempText.toLowerCase().hasIndexOf('soldiers')) {
-				cM.monster = tempText.regex(/\s*([^']+)'s\s+\w+/i).replace(/,.*/,'').toLowerCase().ucWords();
+				cM.monster = tempText.regex(/(?:^The )?([^']+)'s \w+/i).replace(/,.*/,'').toLowerCase().ucWords();
 				cM.monster = monster.getInfo(cM.monster, 'alias', cM.monster);
 				if (visiblePageChangetf && config.getItem("monsterEnableLabels", true)) {
 					tempDiv.text(tempText + " (" + cM.life + "%)");
@@ -1664,7 +1654,7 @@ config,con,gm,schedule,state,general,session,monster:true */
 				link += '&' + temp.match(new RegExp('(' + piece +  '\\w+)'))[1];
 			}
 		});
-		return link.indexOf('=') >= 0 ? link.replace('?&', '?') : monster.lastClick;
+		return (link.indexOf('=') >= 0 ? link.replace('?&', '?') : monster.lastClick).replace('battle_expansion_monster.php','guildv2_battle_monster.php');
 	};
 
     monster.which = function(img, entity) {
@@ -2084,7 +2074,7 @@ config,con,gm,schedule,state,general,session,monster:true */
 				});
 				schedule.setItem('NotargetFrombattle_monster', 0);
 			}
-			state.setItem('wsave_monster', true);
+			monster.save('update');
             localStorage.AFrecentAction = false;
 
             return true;
@@ -2443,398 +2433,93 @@ config,con,gm,schedule,state,general,session,monster:true */
         }
     };
 
-	monster.dashboard = function() {
-		monster.dashboardCommon('Monster');
+	monster.dashboard = {
+		name: 'Monster',
+		inst: 'Display your Monster battles',
+		records: 'monster',
+		filterF: function(cM) {
+			return cM.state != 'Join';
+		},
+		buttons: [{name: 'Refresh Monster List',
+			func: function() {
+				monster.fullReview();
+			}
+		}],
+		tableTemplate: {
+			colorF: function(cM) {
+				return cM.link === state.getItem('targetFromFortify', '') ? 'blue' : 
+					cM.link === state.getItem('targetFromMonster', '') || cM.link === state.getItem('targetFromraid', '') ? 'green' :
+					cM.color;
+				}
+		},
+		tableEntries: [
+			{name: 'Summoner', color: 'blue', 
+				valueF: function(cM) {
+					var link = caap.domain.altered + '/' + cM.link;
+					return '<a href="' + link + '" onclick="ajaxLinkSend(\'globalContainer\', \'' + cM.link + '\'); ' + 
+						' return false;" style="text-decoration:none;font-size:9px;">' +
+						cM.userName + '</a>';
+			}},
+			{name: 'Monster', color: 'blue', 
+				valueF: function(cM) {
+					var link = caap.domain.altered + '/' + cM.link;
+					return '<a href="' + link + '" onclick="ajaxLinkSend(\'globalContainer\', \'' + cM.link + '\'); ' + 
+						' return false;" style="text-decoration:none;font-size:9px;">' +
+						cM.monster + '</a>';
+			}},
+			{name: 'Damage', format: 'SI',
+				titleF: function(cM) {
+					var achLevel = Number(monster.parseCondition('ach', cM.conditions)),
+						maxDamage = monster.parseCondition('max', cM.conditions),
+						title = "Stamina used: " + cM.spentStamina + " Energy used: " + cM.spentEnergy;
+					
+					if (achLevel) {
+						title += " User Set Monster Achievement: " + achLevel.addCommas();
+					} else if (config.getItem('AchievementMode', false)) {
+						title +=  " Default Monster Achievement: " + monster.getInfo(cM, 'ach').addCommas();
+						title += cM.page === 'festival_battle_monster' ? " Festival Monster Achievement: " + monster.getInfo(cM, 'festival_ach').addCommas() : '';
+					} else {
+						title += " Achievement Mode Disabled";
+					}
+
+					title += $u.hasContent(maxDamage) && $u.isNumber(maxDamage) ? " - User Set Max Damage: " + maxDamage.addCommas() : '';
+					return title;
+			}},
+			{name: 'Life%', value: 'life', 
+				titleF: function(cM) {
+					return "Percentage of monster life remaining: " + cM.life + "%";
+			}},
+			{name: 'Fort%', value: 'fortify', format: 'nonnegative',
+				titleF: function(cM) {
+					return (config.getItem('HealPercStam', 20) && cM.debtStamina > 0 ? 'Stamina debt: ' + cM.debtStamina + ' or until Fort % > ' + cM.debtStart + ' ' : '') +"Percentage of party health/monster defense: " + cM.fortify + "%";
+			}},
+			{name: 'Str%', value: 'strength', format: 'nonnegative',
+				titleF: function(cM) {
+					return "Percentage of party strength: " + cM.strength + "%";
+			}},
+			{name: 'Time', format: 'time',
+				titleF: function(cM) {
+					return "Total Monster Duration: " + monster.getInfo(cM, 'duration', 168) + " hours";
+			}},
+			{name: 'T2K', format: 'time',
+				titleF: function(cM) {
+					return "Estimated Time To Kill: " + cM.t2k + " hours:mins";
+			}},
+			{name: 'Phase',
+				valueF: function(cM) {
+					return !['Attack', 'Join'].hasIndexOf(cM.state) ? cM.state : cM.phase >= 0 ?
+						cM.phase + "/" + monster.getInfo(cM, 'siege') + " need " + cM.miss +' next ' + cM.siegeLevel  : '';
+				},
+				titleF: function(cM) {
+					return "Siege: on " + cM.phase +  " of " + monster.getInfo(cM, 'siege') + " phases, need " + cM.miss + ' more clicks. Next click costs ' + cM.siegeLevel;
+			}},
+			{name: '&nbsp;', color: 'blue', format: 'unsortable',
+				valueF: function(cM) {
+					return '<span title="User Set Condition string: ' + $u.setContent(cM.fullC, cM.jFullC) +
+						'" class="ui-icon ui-icon-info">i</span>';
+			}},
+			{name: 'name', type: 'remove'}
+		]
 	};
 	
-	// Creates the Monster Dashboard and Feed Dashboards
-    monster.dashboardCommon = function(which) {
-        try {
-            if (config.getItem('DBDisplay', '') === which && session.getItem(which.toLowerCase() + "DashUpdate", true)) {
-                var headers = ['Name', 'Damage', 'Dmg%', 'Fort%', 'Str%', 'Time', 'T2K', 'Phase', '&nbsp;', '&nbsp;', '&nbsp;'],
-                    values = ['name', 'damage', 'life', 'fortify', 'strength', 'time', 't2k', 'phase', 'link'],
-                    pp = 0,
-                    value = null,
-                    color = '',
-                    monsterConditions = '',
-                    achLevel = 0,
-                    maxDamage = 0,
-                    title = '',
-                    id = '',
-                    link = '',
-                    visitMonsterInstructions = '',
-                    removeLink = '',
-                    removeLinkInstructions = '',
-                    len = 0,
-                    data = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: ''
-                    },
-                    count = 0,
-                    handler = null,
-                    head = '',
-                    body = '',
-                    row = '',
-					whichL = which.toLowerCase();
-
-				if (which == 'Feed') {
-					headers[1] = 'Score';
-					values[1]= 'score';
-				}
-					
-                for (pp = 0, len = headers.length; pp < len; pp += 1) {
-                    switch (headers[pp]) {
-                    case 'Name':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '30%'
-                        });
-                        break;
-                    case 'Damage':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '13%'
-                        });
-                        break;
-                    case 'Score':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '13%'
-                        });
-                        break;
-                    case 'Dmg%':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '8%'
-                        });
-                        break;
-                    case 'Fort%':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '8%'
-                        });
-                        break;
-                    case 'Str%':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '8%'
-                        });
-                        break;
-                    case 'Time':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '8%'
-                        });
-                        break;
-                    case 'T2K':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '8%'
-                        });
-                        break;
-                    case 'Link':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '2%'
-                        });
-                        break;
-                    case 'Phase':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '13%'
-                        });
-                        break;
-                    case '&nbsp;':
-                        head += caap.makeTh({
-                            text: headers[pp],
-                            color: '',
-                            id: '',
-                            title: '',
-                            width: '1%'
-                        });
-                        break;
-                    default:
-						break;
-                    }
-                }
-
-                head = caap.makeTr(head);
-                values.shift();
-                monster.records.forEach(function(cM) {
-					var joinable = cM.state == 'Join',
-						isFeed = which == 'Feed';
-
-					if (joinable != isFeed) {
-						return;
-					}
-                    row = '';
-                    color = cM.color;
-                    if (cM.link === state.getItem('targetFromFortify', '')) {
-                        color = 'blue';
-                    } else if (cM.link === state.getItem('targetFromMonster', '') || cM.link === state.getItem('targetFromraid', '')) {
-                        color = 'green';
-                    }
-
-                    monsterConditions = cM.conditions;
-                    achLevel = Number(monster.parseCondition('ach', monsterConditions));
-                    maxDamage = monster.parseCondition('max', monsterConditions);
-                    if (cM.link.length) {
-                        link = caap.domain.altered + '/' + cM.link;
-                        visitMonsterInstructions = "Clicking this link will take you to " + cM.name;
-                        data = {
-                            text: '<span id="caap_' + whichL + '_' + count + '" title="' + visitMonsterInstructions + '" mname="' + cM.name + '" mlink="' + cM.link +
-                                '" rlink="' + link + '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + cM.name + '</span>',
-                            color: 'blue',
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-                    } else {
-                        row += caap.makeTd({
-                            text: cM.name,
-                            color: color,
-                            id: '',
-                            title: ''
-                        });
-                    }
-
-                    values.forEach(function(displayItem) {
-                        id = "caap_" + displayItem + "_" + count;
-                        title = '';
-                        if (displayItem === 'phase' && color === 'grey') {
-                            row += caap.makeTd({
-                                text: cM.state,
-                                color: color,
-                                id: '',
-                                title: ''
-                            });
-                        } else {
-                            value = cM[displayItem];
-                            if (value !== '' && (value >= 0 || value.length)) {
-                                if (displayItem !== "time" && displayItem !== "t2k" && !$u.isNaN(value) && value > 999) {
-                                    value = value.addCommas();
-                                }
-
-                                switch (displayItem) {
-                                case 'damage':
-									title = "Stamina used: " + cM.spentStamina + " Energy used: " + cM.spentEnergy;
-                                    if (achLevel) {
-                                        title += " User Set Monster Achievement: " + achLevel.addCommas();
-                                    } else if (config.getItem('AchievementMode', false)) {
-                                        title +=  " Default Monster Achievement: " + monster.getInfo(cM, 'ach').addCommas();
-                                        title += cM.page === 'festival_battle_monster' ? " Festival Monster Achievement: " + monster.getInfo(cM, 'festival_ach').addCommas() : '';
-                                    } else {
-                                        title += " Achievement Mode Disabled";
-                                    }
-
-                                    title += $u.hasContent(maxDamage) && $u.isNumber(maxDamage) ? " - User Set Max Damage: " + maxDamage.addCommas() : '';
-                                    break;
-                                case 'time':								
-									value = $u.minutes2hours(value);
-									title = "Total Monster Duration: " + monster.getInfo(cM, 'duration', 168) + " hours";
-                                    break;
-                                case 't2k':
-                                    value = $u.minutes2hours(value);
-                                    title = "Estimated Time To Kill: " + value + " hours:mins";
-                                    break;
-                                case 'life':
-                                    title = "Percentage of monster life remaining: " + value + "%";
-                                    break;
-                                case 'phase':
-                                    value = value + "/" + monster.getInfo(cM, 'siege') + " need " + cM.miss;
-                                    title = "Siege Phase: " + value + " more clicks";
-                                    break;
-                                case 'fortify':
-                                    title = (config.getItem('HealPercStam', 20) && cM.debtStamina > 0 ? 'Stamina debt: ' + cM.debtStamina + ' or until Fort % > ' + cM.debtStart + ' ' : '') +"Percentage of party health/monster defense: " + value + "%";
-                                    break;
-                                case 'strength':
-                                    title = "Percentage of party strength: " + value + "%";
-                                    break;
-                                case 'link':
-                                    value = "<a href='" + link + "'>Link</a>";
-                                    break;
-                                default:
-									break;
-                                }
-
-                                row += caap.makeTd({
-                                    text: value,
-                                    color: color,
-                                    id: id,
-                                    title: title
-                                });
-                            } else {
-                                row += caap.makeTd({
-                                    text: '',
-                                    color: color,
-                                    id: '',
-                                    title: ''
-                                });
-                            }
-                        }
-                    });
-					
-					monsterConditions = $u.setContent(cM.fullC, cM.jFullC);
-
-                    if ($u.hasContent(monsterConditions)) {
-                        data = {
-                            text: '<span title="User Set Condition string: ' + monsterConditions + '" class="ui-icon ui-icon-info">i</span>',
-                            color: 'blue',
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-                    } else {
-                        row += caap.makeTd({
-                            text: '',
-                            color: color,
-                            id: '',
-                            title: ''
-                        });
-                    }
-
-                    if (cM.link.length) {
-                        removeLink = link.replace("casuser", "remove_list") + (cM.page === 'festival_battle_monster' ? '&remove_monsterKey=' + cM.mid.replace("&mid=", "") : '');
-                        removeLinkInstructions = "Clicking this link will remove " + cM.name + " from CAAP. If still on your monster list, it will reappear when CAAP sees it again.";
-                        data = {
-                            text: '<span id="caap_remove_' + count + '" title="' + removeLinkInstructions + '" mname="' + cM.name + '" mlink="' + cM.link +
-                                '" rlink="' + removeLink + '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';" class="ui-icon ui-icon-circle-close">X</span>',
-                            color: 'blue',
-                            id: '',
-                            title: ''
-                        };
-
-                        row += caap.makeTd(data);
-                    } else {
-                        row += caap.makeTd({
-                            text: '',
-                            color: color,
-                            id: '',
-                            title: ''
-                        });
-                    }
-
-                    body += caap.makeTr(row);
-                    count += 1;
-                });
-
-                $j("#caap_info" + which, caap.caapTopObject).html(
-                $j(caap.makeTable(whichL, head, body)).dataTable({
-                    "bAutoWidth": false,
-                    "bFilter": false,
-                    "bJQueryUI": false,
-                    "bInfo": false,
-                    "bLengthChange": false,
-                    "bPaginate": false,
-                    "bProcessing": false,
-                    "bStateSave": true,
-                    "bSortClasses": false,
-                    "aoColumnDefs": [{
-                        "bSortable": false,
-                        "aTargets": [8, 9, 10]
-                    }, {
-                        "sSortDataType": "remaining-time",
-                        "aTargets": [5, 6]
-                    }]
-                }));
-
-                handler = function(e) {
-                    var visitMonsterLink = {
-							mlink: '',
-							mname: '',
-							rlink: '',
-							arlink: ''},
-						ii = 0,
-						len2 = 0;
-
-                    for (ii = 0, len2 = e.target.attributes.length; ii < len2; ii += 1) {
-                        if (e.target.attributes[ii].nodeName === 'mname') {
-                            visitMonsterLink.mname = e.target.attributes[ii].value;
-                        } else if (e.target.attributes[ii].nodeName === 'rlink') {
-                            visitMonsterLink.rlink = e.target.attributes[ii].value;
-                            visitMonsterLink.arlink = visitMonsterLink.rlink.replace(caap.domain.altered + "/", "");
-                        } else if (e.target.attributes[ii].nodeName === 'mlink') {
-                            visitMonsterLink.mlink = e.target.attributes[ii].value;
-                        }
-                    }
-
-					monster.lastClick = visitMonsterLink.mlink;
-					console.log('Visiting link ' + monster.lastClick);
-                    caap.ajaxLink(visitMonsterLink.arlink);
-                };
-
-                $j("span[id*='caap_" + whichL + "_']", caap.caapTopObject).off('click', handler).on('click', handler);
-                handler = null;
-
-                handler = function(e) {
-                    var monsterRemove = {
-                        mlink: '',
-                        mname: '',
-                        rlink: '',
-                        arlink: ''
-                    },
-                    i = 0,
-                    len2 = 0;
-
-                    for (i = 0, len2 = e.target.attributes.length; i < len2; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'mname') {
-                            monsterRemove.mname = e.target.attributes[i].value;
-                        } else if (e.target.attributes[i].nodeName === 'rlink') {
-                            monsterRemove.rlink = e.target.attributes[i].value;
-                            monsterRemove.arlink = monsterRemove.rlink.replace(caap.domain.altered + "/", "");
-                        } else if (e.target.attributes[i].nodeName === 'mlink') {
-                            monsterRemove.mlink = e.target.attributes[i].value;
-                        }
-                    }
-
-					monster.deleteRecord(monsterRemove.mlink);
-                };
-
-                $j("span[id*='caap_remove_']", caap.caapTopObject).off('click', handler).on('click', handler);
-                handler = null;
-                session.setItem(which.toLowerCase() + "DashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in monster.dashboardCommon: " + err.stack, which);
-            return false;
-        }
-    };
-
 }());

--- a/Chrome/unpacked/js/worker_recon.js
+++ b/Chrome/unpacked/js/worker_recon.js
@@ -36,6 +36,12 @@ recon worker holds the records for possible good targets that haven't been hit y
 	recon.init = function(which) {
 		try {
 			which = $u.setContent(which, config.getItem('battleWhich', 'Invade'));
+			
+			if (!$u.hasContent(recon.dashboard.tableEntries)) {
+				recon.dashboard.tableEntries = battle.dashboard.tableEntries.filter( function(e) {
+					return ['UserId', 'Name', 'BR', 'WR', 'FR', 'Level', 'Army', 'name'].hasIndexOf(e.name);
+				});
+			}
 				
 			var w = battle[which],
 				recName = w.recon,
@@ -64,208 +70,13 @@ recon worker holds the records for possible good targets that haven't been hit y
         }
     };
 	
-    recon.dashboard = function() {
-        try {
-            var headers = [],
-                values = [],
-                pp = 0,
-                i = 0,
-                userIdLink = '',
-                userIdLinkInstructions = '',
-                len = 0,
-                data = {
-                    text: '',
-                    color: '',
-                    bgcolor: '',
-                    id: '',
-                    title: ''
-                },
-                handler = null,
-                head = '',
-                body = '',
-                row = '';
-
-            /*-------------------------------------------------------------------------------------\
-            Next we build the HTML to be included into the 'caap_infoTargets1' div. We set our
-            table and then build the header row.
-            \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Target List' && session.getItem("ReconDashUpdate", true)) {
-                head = "";
-                body = "";
-                headers = ['UserId', 'Name', 'Deity', 'BR#', 'Arena#',
-                'WR#', 'Level', 'Army'];
-                values = ['userId', 'name', 'deity', 'rank', 'arenaRank',
-                'warRank', 'level', 'army'];
-                for (pp = 0; pp < headers.length; pp += 1) {
-                    switch (headers[pp]) {
-                        case 'UserId':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '16%'
-                            });
-
-                            break;
-                        case 'Name':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '25%'
-                            });
-
-                            break;
-                        case 'Deity':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '12%'
-                            });
-
-                            break;
-                        case 'BR#':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '7%'
-                            });
-
-                            break;
-                        case 'arena#':
-                            head += caap.makeTh({
-                                text : headers[pp],
-                                width : '7%'
-                            });
-
-                            break;
-                        case 'WR#':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '7%'
-                            });
-
-                            break;
-                        case 'Level':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '7%'
-                            });
-
-                            break;
-                        case 'Army':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '7%'
-                            });
-
-                            break;
-                        case 'Last Alive':
-                            head += caap.makeTh({
-                                text: headers[pp],
-                                width: '12%'
-                            });
-
-                            break;
-                        default:
-							break;
-                    }
-                }
-
-                head = caap.makeTr(head);
-                for (i = 0, len = recon.records.length; i < len; i += 1) {
-                    row = "";
-                    for (pp = 0; pp < values.length; pp += 1) {
-                        switch (values[pp]) {
-                            case 'userId':
-                                userIdLinkInstructions = "Clicking this link will take you to the user keep of " + recon.records[i][values[pp]];
-                                userIdLink = "keep.php?casuser=" + recon.records[i][values[pp]];
-                                data = {
-                                    text: '<span id="caap_targetrecon_' + i + '" title="' + userIdLinkInstructions + '" rlink="' + userIdLink +
-                                        '" onmouseover="this.style.cursor=\'pointer\';" onmouseout="this.style.cursor=\'default\';">' + recon.records[i][values[pp]] + '</span>',
-                                    color: 'blue'
-                                };
-
-                                row += caap.makeTd(data);
-
-                                break;
-                            case 'deityNum':
-                                row += caap.makeTd({
-                                    text: caap.demiTable[recon.records[i][values[pp]]].ucFirst()
-                                });
-
-                                break;
-                            case 'rankNum':
-                                row += caap.makeTd({
-                                    text: recon.records[i][values[pp]],
-                                    title: battle.battleRankTable[recon.records[i][values[pp]]]
-                                });
-
-                                break;
-                            case 'arenaRankNum':
-                                row += caap.makeTd({
-                                    text : recon.records[i][values[pp]],
-                                    title : battle.battleRankTable[recon.records[i][values[pp]]]
-                                });
-
-                                break;
-                            case 'warRankNum':
-                                row += caap.makeTd({
-                                    text: recon.records[i][values[pp]],
-                                    title: battle.warRankTable[recon.records[i][values[pp]]]
-                                });
-
-                                break;
-                            case 'aliveTime':
-                                data = {
-                                    text: $u.makeTime(recon.records[i][values[pp]], "d M H:i")
-                                };
-
-                                row += caap.makeTd(data);
-
-                                break;
-                            default:
-                                row += caap.makeTd({
-                                    text: recon.records[i][values[pp]]
-                                });
-                        }
-                    }
-
-                    body += caap.makeTr(row);
-                }
-
-                $j("#caap_infoTargets1", caap.caapTopObject).html($j(caap.makeTable("recon", head, body)).dataTable({
-                    "bAutoWidth": false,
-                    "bFilter": false,
-                    "bJQueryUI": false,
-                    "bInfo": false,
-                    "bLengthChange": false,
-                    "bPaginate": false,
-                    "bProcessing": false,
-                    "bStateSave": true,
-                    "bSortClasses": false
-                }));
-
-                handler = function (e) {
-                    var visitUserIdLink = {
-                            rlink: '',
-                            arlink: ''
-                        },
-                        i = 0,
-                        len = 0;
-
-                    for (i = 0, len = e.target.attributes.length; i < len; i += 1) {
-                        if (e.target.attributes[i].nodeName === 'rlink') {
-                            visitUserIdLink.rlink = e.target.attributes[i].nodeValue;
-                            visitUserIdLink.arlink = visitUserIdLink.rlink;
-                        }
-                    }
-
-                    caap.ajaxLink(visitUserIdLink.arlink);
-                };
-
-                $j("span[id*='caap_targetrecon_']", caap.caapTopObject).off('click', handler).click(handler);
-                session.setItem("ReconDashUpdate", false);
-            }
-            return true;
-        } catch (err) {
-            con.error("ERROR in stats.dashboard: " + err);
-            return false;
-        }
-    };
+	recon.dashboard = {
+		name: 'Recon Stats',
+		inst: 'Display information about Targets that you have performed reconnaissance on',
+		records: 'recon',
+		buttons: ['clear'],
+		tableTemplate: { width: '10%' },
+		// Additional entries filled in recon.init from battle dash
+	};
 
 }());

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -1,7 +1,7 @@
 /*jslint white: true, browser: true, devel: true,
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
-/*global $j,$u,caap,config,con,state,session,worker,stats,statsFunc,
+/*global $j,$u,caap,config,con,state,session,worker,stats,statsFunc,ignoreJSLintError,
 gm,hiddenVar,battle,general */
 /*jslint maxlen: 256 */
 
@@ -226,6 +226,7 @@ gm,hiddenVar,battle,general */
 	
 	statsFunc.check = function(page) {
         try {
+			ignoreJSLintError(page);
             var passed = true,
                 tNum = 0,
                 xS = 0,
@@ -492,233 +493,43 @@ gm,hiddenVar,battle,general */
 					temp = "<div style='background-image:url(\"" + caap.domain.protocol[caap.domain.ptype] +
 						"castleagegame1-a.akamaihd.net/32703/graphics/keep_tabsubheader_mid.jpg\");border:none;padding: 5px 5px 20px 20px;width:715px;font-weight:bold;font-family:Verdana;sans-serif;background-repeat:y-repeat;'>";
 					temp += "<div style='border:1px solid #701919;padding: 5px 5px;width:688px;height:100px;background-color:#d0b682;'>";
-					row = caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '5%'
-					});
+					row = caap.makeTh({text: '&nbsp;', width: '5%'});
 
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '10%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '20%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '10%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '20%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '10%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '20%'
-					});
-
-					row += caap.makeTh({
-						text: '&nbsp;',
-						color: '',
-						bgcolor: '',
-						id: '',
-						title: '',
-						width: '5%'
-					});
-
+					row += caap.makeTh({text: '&nbsp;', width: '10%'});
+					row += caap.makeTh({text: '&nbsp;', width: '20%'});
+					row += caap.makeTh({text: '&nbsp;', width: '10%'});
+					row += caap.makeTh({text: '&nbsp;', width: '20%'});
+					row += caap.makeTh({text: '&nbsp;', width: '10%'});
+					row += caap.makeTh({text: '&nbsp;', width: '20%'});
+					row += caap.makeTh({text: '&nbsp;', width: '5%'});
 					head = caap.makeTr(row);
-
-					row = caap.makeTd({
-						text: '',
-						color: '',
-						id: '',
-						title: ''
-					});
-
-					row += caap.makeTd({
-						text: 'BSI',
-						color: '',
-						id: '',
-						title: 'Battle Strength Index'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.bsi + ' (' + stats.indicators.bsib + ')',
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'LSI',
-						color: '',
-						id: '',
-						title: 'Leveling Speed Index'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.lsi,
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'SPPL',
-						color: '',
-						id: '',
-						title: 'Skill Points Per Level (More accurate than SPAEQ)'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.sppl + ' (' + stats.indicators.spplb + ')',
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
+					
+					row = caap.makeTd({text: '', title: ''});
+					row += caap.makeTd({text: 'BSI', title: 'Battle Strength Index'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.bsi + ' (' + stats.indicators.bsib + ')', title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'LSI', title: 'Leveling Speed Index'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.lsi, title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'SPPL', title: 'Skill Points Per Level (More accurate than SPAEQ)'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.sppl + ' (' + stats.indicators.spplb + ')', title: ''}, "font-size:14px;");
 					body = caap.makeTr(row);
-
-					row = caap.makeTd({
-						text: '',
-						color: '',
-						id: '',
-						title: ''
-					});
-
-					row += caap.makeTd({
-						text: 'API',
-						color: '',
-						id: '',
-						title: 'Attack Power Index'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.api + ' (' + stats.bonus.api + ')',
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'DPI',
-						color: '',
-						id: '',
-						title: 'Defense Power Index'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.dpi + ' (' + stats.bonus.dpi + ')',
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'MPI',
-						color: '',
-						id: '',
-						title: 'Mean Power Index'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.mpi,
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
+					
+					row = caap.makeTd({text: '', title: ''});
+					row += caap.makeTd({text: 'API', title: 'Attack Power Index'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.api + ' (' + stats.bonus.api + ')', title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'DPI', title: 'Defense Power Index'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.dpi + ' (' + stats.bonus.dpi + ')', title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'MPI', title: 'Mean Power Index'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.mpi, title: ''}, "font-size:14px;");
 					body += caap.makeTr(row);
-
-					row = caap.makeTd({
-						text: '',
-						color: '',
-						id: '',
-						title: ''
-					});
-
-					row += caap.makeTd({
-						text: 'eSTA',
-						color: '',
-						id: '',
-						title: 'Effective Daily Stamina'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.eSta,
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'eEne',
-						color: '',
-						id: '',
-						title: 'Effective Daily Energy'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.eEne,
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: 'PvP Class',
-						color: '',
-						id: '',
-						title: 'Player vs. Player character class'
-					}, "font-size:14px;");
-
-					row += caap.makeTd({
-						text: stats.indicators.pvpclass,
-						color: '',
-						id: '',
-						title: ''
-					}, "font-size:14px;");
-
+					
+					row = caap.makeTd({text: '', title: ''});
+					row += caap.makeTd({text: 'eSTA', title: 'Effective Daily Stamina'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.eSta, title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'eEne', title: 'Effective Daily Energy'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.eEne, title: ''}, "font-size:14px;");
+					row += caap.makeTd({text: 'PvP Class', title: 'Player vs. Player character class'}, "font-size:14px;");
+					row += caap.makeTd({text: stats.indicators.pvpclass, title: ''}, "font-size:14px;");
 					body += caap.makeTr(row);
-
 					temp += caap.makeTable("keepstats", head, body, "Statistics", "font-size:16px;");
 					temp += "</div></div>";
 					tempDiv.after(temp);
@@ -879,6 +690,8 @@ gm,hiddenVar,battle,general */
                 health = stats.health.norm,
                 action = false;
 
+			ignoreJSLintError(level, energy, stamina, attack, defense, health);
+			
 			(advanced ? [5, 6, 7, 8, 9] : [0, 1, 2, 3, 4]).some( function(n) {
                 attribute = config.getItem('Attribute' + n, '').toLowerCase();
 
@@ -930,13 +743,15 @@ gm,hiddenVar,battle,general */
             return false;
         }
     };
-	
-    statsFunc.dashboard = function() {
-        try {
+
+	statsFunc.dashboard = {
+		name: 'Stats',
+		inst: 'Display information about your account and character statistics',
+		records: 'statsFunc',
+		headerF: function() {
             var headers = [],
                 pp = 0,
                 count = 0,
-                valueCol = 'red',
                 len = 0,
                 head = '',
                 body = '',
@@ -947,633 +762,145 @@ gm,hiddenVar,battle,general */
             Next we build the HTML to be included into the 'caap_userStats' div. We set our
             table and then build the header row.
             \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'User Stats' && session.getItem("UserDashUpdate", true)) {
-                head = "";
-                body = "";
-                headers = ['Name', 'Value', 'Name', 'Value'];
-                for (pp = 0, len = headers.length; pp < len; pp += 1) {
-                    head += caap.makeTh({
-                        text: headers[pp],
-                        width: ''
-                    });
-                }
+			head = "";
+			body = "";
+			headers = ['Name', 'Value', 'Name', 'Value'];
+			for (pp = 0, len = headers.length; pp < len; pp += 1) {
+				head += caap.makeTh({text: headers[pp],
+					width: ''});
+			}
 
-                head = caap.makeTr(head);
-                rows = [
-                    [{
-                        text: 'Facebook ID'
-                    }, {
-                        text: stats.FBID
-                    }, {
-                        text: 'Account Name'
-                    }, {
-                        text: caap.fbData.me.name
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;'
-                    }],
-                    [{
-                        text: 'Character Name'
-                    }, {
-                        text: stats.PlayerName
-                    }, {
-                        text: 'Energy',
-                        title: 'Current/Max'
-                    }, {
-                        text: stats.energy.num + '/' + stats.energy.max,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Level'
-                    }, {
-                        text: stats.level,
-                        color: valueCol
-                    }, {
-                        text: 'Stamina',
-                        title: 'Current/Max'
-                    }, {
-                        text: stats.stamina.num + '/' + stats.stamina.max,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Battle Rank'
-                    }, {
-                        text: battle.ranks.rank[stats.rank.battle] + ' (' + stats.rank.battle + ')',
-                        color: valueCol
-                    }, {
-                        text: 'Attack',
-                        title: 'Current/Max'
-                    }, {
-                        text: stats.attack.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Battle Rank Points'
-                    }, {
-                        text: 'Unknown',
-                        color: valueCol
-                    }, {
-                        text: 'Defense'
-                    }, {
-                        text: stats.defense.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'War Rank'
-                    }, {
-                        text: battle.ranks.warRank[stats.rank.war] + ' (' + stats.rank.war + ')',
-                        color: valueCol
-                    }, {
-                        text: 'Health',
-                        title: 'Current/Max'
-                    }, {
-                        text: stats.health.num + '/' + stats.health.max,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'War Rank Points'
-                    }, {
-                        text: 'Unknown',
-                        color: valueCol
-                    }, {
-                        text: 'Army'
-                    }, {
-                        text: stats.army.actual.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Conquest Rank'
-                    }, {
-                        text: battle.ranks.conqRank[stats.rank.conquest] + ' (' + stats.rank.conquest + ')',
-                        color: valueCol
-                    }, {
-                        text: 'Generals'
-                    }, {
-                        text: general.records.length,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Conquest Rank Points'
-                    }, {
-                        text: 'Unknown',
-                        color: valueCol
-                    }, {
-                        text: 'Generals When Invade',
-                        title: 'For every 5 army members you have, one of your generals will also join the fight.'
-                    }, {
-                        text: Math.min((stats.army.actual / 5).dp(), general.records.length),
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Gold In Bank'
-                    }, {
-                        text: '$' + stats.gold.bank.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Total Income Per Hour'
-                    }, {
-                        text: '$' + stats.gold.income.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Gold In Cash'
-                    }, {
-                        text: '$' + stats.gold.cash.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Upkeep'
-                    }, {
-                        text: '$' + stats.gold.upkeep.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Total Gold'
-                    }, {
-                        text: '$' + stats.gold.total.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Cash Flow Per Hour'
-                    }, {
-                        text: '$' + stats.gold.flow.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Skill Points'
-                    }, {
-                        text: stats.points.skill,
-                        color: valueCol
-                    }, {
-                        text: 'Energy Potions'
-                    }, {
-                        text: stats.potions.energy,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Favor Points'
-                    }, {
-                        text: stats.points.favor,
-                        color: valueCol
-                    }, {
-                        text: 'Stamina Potions'
-                    }, {
-                        text: stats.potions.stamina,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Experience To Next Level (ETNL)'
-                    }, {
-                        text: stats.exp.dif.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Battle Strength Index (BSI)'
-                    }, {
-                        text: stats.indicators.bsi,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Hours To Level (HTL)'
-                    }, {
-                        text: $u.minutes2hours(stats.indicators.htl),
-                        color: valueCol
-                    }, {
-                        text: 'Levelling Speed Index (LSI)'
-                    }, {
-                        text: stats.indicators.lsi,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Hours Remaining To Level (HRTL)'
-                    }, {
-                        text: $u.minutes2hours(stats.indicators.hrtl),
-                        color: valueCol
-                    }, {
-                        text: 'Skill Points Per Level (SPPL)'
-                    }, {
-                        text: stats.indicators.sppl,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Expected Next Level (ENL)'
-                    }, {
-                        text: $u.makeTime(stats.indicators.enl, caap.timeStr()),
-                        color: valueCol
-                    }, {
-                        text: 'Attack Power Index (API)'
-                    }, {
-                        text: stats.indicators.api,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Build Type'
-                    }, {
-                        text: stats.indicators.build,
-                        color: valueCol
-                    }, {
-                        text: 'Defense Power Index (DPI)'
-                    }, {
-                        text: stats.indicators.dpi,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'PvP Class'
-                    }, {
-                        text: stats.indicators.pvpclass,
-                        color: valueCol
-                    }, {
-                        text: 'Mean Power Index (MPI)'
-                    }, {
-                        text: stats.indicators.mpi,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: 'Monster Hunting Build Effective Quotent (MHBEQ)'
-                    }, {
-                        text: stats.indicators.mhbeq,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Battles/Wars Won'
-                    }, {
-                        text: stats.other.bww.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Times eliminated'
-                    }, {
-                        text: stats.other.te.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Battles/Wars Lost'
-                    }, {
-                        text: stats.other.bwl.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Times you eliminated an enemy'
-                    }, {
-                        text: stats.other.tee.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Battles/Wars Win/Loss Ratio (WLR)'
-                    }, {
-                        text: stats.other.wlr,
-                        color: valueCol
-                    }, {
-                        text: 'Enemy Eliminated/Eliminated Ratio (EER)'
-                    }, {
-                        text: stats.other.eer,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Invasions Won'
-                    }, {
-                        text: stats.achievements.battle.invasions.won.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Duels Won'
-                    }, {
-                        text: stats.achievements.battle.duels.won.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Invasions Lost'
-                    }, {
-                        text: stats.achievements.battle.invasions.lost.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Duels Lost'
-                    }, {
-                        text: stats.achievements.battle.duels.lost.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Invasions Streak'
-                    }, {
-                        text: stats.achievements.battle.invasions.streak.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Duels Streak'
-                    }, {
-                        text: stats.achievements.battle.duels.streak.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Invasions Win/loss Ratio (IWLR)'
-                    }, {
-                        text: stats.achievements.battle.invasions.ratio,
-                        color: valueCol
-                    }, {
-                        text: 'Duels Win/loss Ratio (DWLR)'
-                    }, {
-                        text: stats.achievements.battle.duels.ratio,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Quests Completed'
-                    }, {
-                        text: stats.other.qc.addCommas(),
-                        color: valueCol
-                    }, {
-                        text: 'Alchemy Performed'
-                    }, {
-                        text: stats.achievements.other.alchemy.addCommas(),
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }]
-                ];
+			head = caap.makeTr(head);
+			rows = [
+				[{text: 'Facebook ID'}, {text: stats.FBID}, {text: 'Account Name'}, {text: caap.fbData.me.name},
+					{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Character Name'}, {text: stats.PlayerName},
+					{text: 'Energy', title: 'Current/Max'}, {text: stats.energy.num + '/' + stats.energy.max}],
+				[{text: 'Level'}, {text: stats.level}, 
+					{text: 'Stamina', title: 'Current/Max'}, {text: stats.stamina.num + '/' + stats.stamina.max}],
+				[{text: 'Battle Rank'}, {text: battle.ranks.rank[stats.rank.battle] + ' (' + stats.rank.battle + ')'},
+					{text: 'Attack', title: 'Current/Max'}, {text: stats.attack.addCommas()}],
+				[{text: 'Battle Rank Points'}, {text: 'Unknown'},
+					{text: 'Defense'}, {text: stats.defense.addCommas()}],
+				[{text: 'War Rank'}, {text: battle.ranks.warRank[stats.rank.war] + ' (' + stats.rank.war + ')'},
+					{text: 'Health', title: 'Current/Max'}, {text: stats.health.num + '/' + stats.health.max}],
+				[{text: 'War Rank Points'}, {text: 'Unknown'}, {text: 'Army'}, {text: stats.army.actual.addCommas()}],
+				[{text: 'Conquest Rank'}, {text: battle.ranks.conqRank[stats.rank.conquest] + ' (' + stats.rank.conquest + ')'},
+					{text: 'Generals'}, {text: general.records.length}],
+				[{text: 'Conquest Rank Points'}, {text: 'Unknown'},
+					{text: 'Generals When Invade', title: 'For every 5 army members you have, one of your generals will also join the fight.'}, {text: Math.min((stats.army.actual / 5).dp(), general.records.length)}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Gold In Bank'}, {text: '$' + stats.gold.bank.addCommas()},
+					{text: 'Total Income Per Hour'}, {text: '$' + stats.gold.income.addCommas()}],
+				[{text: 'Gold In Cash'}, {text: '$' + stats.gold.cash.addCommas()},
+					{text: 'Upkeep'}, {text: '$' + stats.gold.upkeep.addCommas()}],
+				[{text: 'Total Gold'}, {text: '$' + stats.gold.total.addCommas()},
+					{text: 'Cash Flow Per Hour'}, {text: '$' + stats.gold.flow.addCommas()}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Skill Points'}, {text: stats.points.skill},
+					{text: 'Energy Potions'}, {text: stats.potions.energy}],
+				[{text: 'Favor Points'}, {text: stats.points.favor},
+					{text: 'Stamina Potions'}, {text: stats.potions.stamina}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Experience To Next Level (ETNL)'}, {text: stats.exp.dif.addCommas()}, {text: 'Battle Strength Index (BSI)'}, {text: stats.indicators.bsi}],
+				[{text: 'Hours To Level (HTL)'}, {text: $u.minutes2hours(stats.indicators.htl)}, {text: 'Levelling Speed Index (LSI)'}, {text: stats.indicators.lsi}],
+				[{text: 'Hours Remaining To Level (HRTL)'}, {text: $u.minutes2hours(stats.indicators.hrtl)}, {text: 'Skill Points Per Level (SPPL)'}, {text: stats.indicators.sppl}],
+				[{text: 'Expected Next Level (ENL)'}, {text: $u.makeTime(stats.indicators.enl, caap.timeStr())}, {text: 'Attack Power Index (API)'}, {text: stats.indicators.api}],
+				[{text: 'Build Type'}, {text: stats.indicators.build}, {text: 'Defense Power Index (DPI)'}, {text: stats.indicators.dpi}],
+				[{text: 'PvP Class'}, {text: stats.indicators.pvpclass}, {text: 'Mean Power Index (MPI)'}, {text: stats.indicators.mpi}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: 'Monster Hunting Build Effective Quotent (MHBEQ)'}, {text: stats.indicators.mhbeq}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Battles/Wars Won'}, {text: stats.other.bww.addCommas()}, {text: 'Times eliminated'}, {text: stats.other.te.addCommas()}],
+				[{text: 'Battles/Wars Lost'}, {text: stats.other.bwl.addCommas()}, {text: 'Times you eliminated an enemy'}, {text: stats.other.tee.addCommas()}],
+				[{text: 'Battles/Wars Win/Loss Ratio (WLR)'}, {text: stats.other.wlr}, {text: 'Enemy Eliminated/Eliminated Ratio (EER)'}, {text: stats.other.eer}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Invasions Won'}, {text: stats.achievements.battle.invasions.won.addCommas()}, {text: 'Duels Won'}, {text: stats.achievements.battle.duels.won.addCommas()}],
+				[{text: 'Invasions Lost'}, {text: stats.achievements.battle.invasions.lost.addCommas()}, {text: 'Duels Lost'}, {text: stats.achievements.battle.duels.lost.addCommas()}],
+				[{text: 'Invasions Streak'}, {text: stats.achievements.battle.invasions.streak.addCommas()}, {text: 'Duels Streak'}, {text: stats.achievements.battle.duels.streak.addCommas()}],
+				[{text: 'Invasions Win/loss Ratio (IWLR)'}, {text: stats.achievements.battle.invasions.ratio}, {text: 'Duels Win/loss Ratio (DWLR)'}, {text: stats.achievements.battle.duels.ratio}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Quests Completed'}, {text: stats.other.qc.addCommas()}, {text: 'Alchemy Performed'}, {text: stats.achievements.other.alchemy.addCommas()}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}]
+			];
 
-                $j.each(rows, function () {
-                    var _row = '';
+			$j.each(rows, function () {
+				var _row = '';
 
-                    $j.each(this, function () {
-                        _row += caap.makeTd(this);
-                    });
+				$j.each(this, function () {
+					_row += caap.makeTd(this);
+				});
 
-                    body += caap.makeTr(_row);
-                });
+				body += caap.makeTr(_row);
+			});
 
-                count = 0;
-                for (pp in stats.achievements.monster) {
-                    if (stats.achievements.monster.hasOwnProperty(pp)) {
-                        row = count % 2 === 0 ? '' : row;
-                        row += caap.makeTd({
-                            text: pp.escapeHTML()
-                        });
+			count = 0;
+			for (pp in stats.achievements.monster) {
+				if (stats.achievements.monster.hasOwnProperty(pp)) {
+					row = count % 2 === 0 ? '' : row;
+					row += caap.makeTd({text: pp.escapeHTML()});
 
-                        row += caap.makeTd({
-                            text: stats.achievements.monster[pp],
-                            color: valueCol
-                        });
+					row += caap.makeTd({text: stats.achievements.monster[pp]});
 
-                        body += count % 2 === 1 ? caap.makeTr(row) : '';
-                        count += 1;
-                    }
-                }
+					body += count % 2 === 1 ? caap.makeTr(row) : '';
+					count += 1;
+				}
+			}
 
-                if (count % 2 === 1) {
-                    row += caap.makeTd({
-                        text: '&nbsp;'
-                    });
+			if (count % 2 === 1) {
+				row += caap.makeTd({text: '&nbsp;'});
 
-                    row += caap.makeTd({
-                        text: '&nbsp;',
-                        color: valueCol
-                    });
+				row += caap.makeTd({text: '&nbsp;'});
 
-                    body += caap.makeTr(row);
-                }
+				body += caap.makeTr(row);
+			}
 
-                rows = [
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Ambrosia Daily Points'
-                    }, {
-                        text: caap.demi.ambrosia.daily.num + '/' + caap.demi.ambrosia.daily.max,
-                        color: valueCol
-                    }, {
-                        text: 'Malekus Daily Points'
-                    }, {
-                        text: caap.demi.malekus.daily.num + '/' + caap.demi.malekus.daily.max,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Ambrosia Total Points'
-                    }, {
-                        text: caap.demi.ambrosia.power.total,
-                        color: valueCol
-                    }, {
-                        text: 'Malekus Total Points'
-                    }, {
-                        text: caap.demi.malekus.power.total,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Corvintheus Daily Points'
-                    }, {
-                        text: caap.demi.corvintheus.daily.num + '/' + caap.demi.corvintheus.daily.max,
-                        color: valueCol
-                    }, {
-                        text: 'Aurora Daily Points'
-                    }, {
-                        text: caap.demi.aurora.daily.num + '/' + caap.demi.aurora.daily.max,
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Corvintheus Total Points'
-                    }, {
-                        text: caap.demi.corvintheus.power.total,
-                        color: valueCol
-                    }, {
-                        text: 'Aurora Total Points'
-                    }, {
-                        text: caap.demi.aurora.power.total,
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Azeron Daily Points'
-                    }, {
-                        text: caap.demi.azeron.daily.num + '/' + caap.demi.azeron.daily.max,
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: 'Azeron Total Points'
-                    }, {
-                        text: caap.demi.azeron.power.total,
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }],
-                    [{
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }, {
-                        text: '&nbsp;'
-                    }, {
-                        text: '&nbsp;',
-                        color: valueCol
-                    }]
-                ];
+			rows = [
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Ambrosia Daily Points'}, {text: caap.demi.ambrosia.daily.num + '/' + caap.demi.ambrosia.daily.max}, {text: 'Malekus Daily Points'}, {text: caap.demi.malekus.daily.num + '/' + caap.demi.malekus.daily.max}],
+				[{text: 'Ambrosia Total Points'}, {text: caap.demi.ambrosia.power.total}, {text: 'Malekus Total Points'}, {text: caap.demi.malekus.power.total}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Corvintheus Daily Points'}, {text: caap.demi.corvintheus.daily.num + '/' + caap.demi.corvintheus.daily.max}, {text: 'Aurora Daily Points'}, {text: caap.demi.aurora.daily.num + '/' + caap.demi.aurora.daily.max}],
+				[{text: 'Corvintheus Total Points'}, {text: caap.demi.corvintheus.power.total}, {text: 'Aurora Total Points'}, {text: caap.demi.aurora.power.total}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Azeron Daily Points'}, {text: caap.demi.azeron.daily.num + '/' + caap.demi.azeron.daily.max}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: 'Azeron Total Points'}, {text: caap.demi.azeron.power.total}, {text: '&nbsp;'}, {text: '&nbsp;'}],
+				[{text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}, {text: '&nbsp;'}]
+			];
 
-                $j.each(rows, function () {
-                    var _row = '';
+			$j.each(rows, function () {
+				var _row = '';
 
-                    $j.each(this, function () {
-                        _row += caap.makeTd(this);
-                    });
+				$j.each(this, function () {
+					_row += caap.makeTd(this);
+				});
 
-                    body += caap.makeTr(_row);
-                });
+				body += caap.makeTr(_row);
+			});
 
-                body += caap.makeTr(row);
-                count = 0;
-                for (pp in stats.character) {
-                    if (stats.character.hasOwnProperty(pp)) {
-                        row = count % 2 === 0 ? '' : row;
-                        row += caap.makeTd({
-                            text: pp
-                        });
+			body += caap.makeTr(row);
+			count = 0;
+			for (pp in stats.character) {
+				if (stats.character.hasOwnProperty(pp)) {
+					row = count % 2 === 0 ? '' : row;
+					row += caap.makeTd({text: pp});
 
-                        row += caap.makeTd({
-                            text: "Level " + stats.character[pp].level + " (" + stats.character[pp].percent + "%)",
-                            color: valueCol
-                        });
+					row += caap.makeTd({text: "Level " + stats.character[pp].level + " (" + stats.character[pp].percent + "%)"});
 
-                        body += count % 2 === 1 ? caap.makeTr(row) : '';
-                        count += 1;
-                    }
-                }
+					body += count % 2 === 1 ? caap.makeTr(row) : '';
+					count += 1;
+				}
+			}
 
-                if (count % 2 === 1) {
-                    row += caap.makeTd({
-                        text: '&nbsp;'
-                    });
+			if (count % 2 === 1) {
+				row += caap.makeTd({text: '&nbsp;'});
 
-                    row += caap.makeTd({
-                        text: '&nbsp;',
-                        color: valueCol
-                    });
+				row += caap.makeTd({text: '&nbsp;'});
 
-                    body += caap.makeTr(row);
-                }
+				body += caap.makeTr(row);
+			}
 
-                $j("#caap_userStats", caap.caapTopObject).html(caap.makeTable("user", head, body));
-                session.setItem("UserDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in statsFunc.dashboard: " + err.stack);
-            return false;
-        }
-    };
+            return caap.makeTable("user", head, body);
+		}};
 
     statsFunc.menu = function () {
         try {

--- a/Chrome/unpacked/js/worker_town.js
+++ b/Chrome/unpacked/js/worker_town.js
@@ -1,9 +1,9 @@
 
-/*jslint white: true, browser: true, devel: true, undef: true,
+/*jslint white: true, browser: true, devel: true,
 nomen: true, bitwise: true, plusplus: true,
 regexp: true, eqeq: true, newcap: true, forin: false */
 /*global window,escape,jQuery,$j,rison,utility,offline,town,gm,
-$u,chrome,CAAP_SCOPE_RUN,self,caap,config,con,spreadsheet,ss,
+$u,chrome,worker,self,caap,config,con,spreadsheet,ss,
 schedule,gifting,state,army, general,session,monster,guild_monster */
 /*jslint maxlen: 256 */
 
@@ -37,11 +37,11 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         };
     };
 
-	worker.addPageCheck({page : 'soldiers'});
+	worker.addPageCheck({page : 'soldiers', config: 'itemIventory'});
 		
-	worker.addPageCheck({page : 'item'});
+	worker.addPageCheck({page : 'item', config: 'itemIventory'});
 		
-	worker.addPageCheck({page : 'magic'});
+	worker.addPageCheck({page : 'magic', config: 'itemIventory'});
 	
 	town.checkResults = function(page) {
         try {
@@ -107,6 +107,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 
 					town.setRecord(current);
 				});
+				break;
 
 			default :
 				break;
@@ -121,129 +122,23 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
         return $u.isString(image) ? $u.setContent(town.getRecord(image).owned, 0) : 0;
     };
 
-    town.dashboard = function() {
-        try {
-            /*-------------------------------------------------------------------------------------\
-                Next we build the HTML to be included into the 'soldiers', 'item' and 'magic' div.
-                We set our table and then build the header row.
-                \-------------------------------------------------------------------------------------*/
-            if (config.getItem('DBDisplay', '') === 'Town Stats' && session.getItem("townDashUpdate", true)) {
-                var headers = ['Name', 'Type', 'Own', 'Atk', 'Def', 'API', 'DPI', 'MPI', 'Cost', 'Upkeep', 'Hourly'],
-                    values = ['name', 'type', 'owned', 'atk', 'def', 'api', 'dpi', 'mpi', 'cost', 'upkeep', 'hourly'],
-                    pp = 0,
-                    i = 0,
-                    it = 0,
-                    len = 0,
-                    len1 = 0,
-                    len2 = 0,
-                    str = '',
-                    num = 0,
-                    header = {
-                        text: '',
-                        color: '',
-                        bgcolor: '',
-                        id: '',
-                        title: '',
-                        width: ''
-                    },
-                    head = '',
-                    body = '',
-                    row = '';
-
-				for (pp = 0, len1 = headers.length; pp < len1; pp += 1) {
-
-					header = {
-						text: headers[pp],
-						color: '',
-						id: '',
-						title: '',
-						width: ''
-					};
-
-					switch (headers[pp]) {
-					case 'Name':
-						header.width = '30%';
-						break;
-					case 'Type':
-						header.width = '7%';
-						break;
-					case 'Own':
-						header.width = '6%';
-						break;
-					case 'Atk':
-						header.width = '6%';
-						break;
-					case 'Def':
-						header.width = '6%';
-						break;
-					case 'API':
-						header.width = '6%';
-						break;
-					case 'DPI':
-						header.width = '6%';
-						break;
-					case 'MPI':
-						header.width = '6%';
-						break;
-					case 'Cost':
-						header.width = '9%';
-						break;
-					case 'Upkeep':
-						header.width = '9%';
-						break;
-					case 'Hourly':
-						header.width = '9%';
-						break;
-					default:
-					}
-
-					head += caap.makeTh(header);
-				}
-
-				head = caap.makeTr(head);
-				for (it = 0, len1 = town.records.length; it < len1; it += 1) {
-					row = "";
-					for (pp = 0, len2 = values.length; pp < len2; pp += 1) {
-
-						if ($u.isNaN(town.records[it][values[pp]]) || !$u.hasContent(town.records[it][values[pp]])) {
-							str = $u.setContent(town.records[it][values[pp]], '');
-						} else {
-							num = town.records[it][values[pp]];
-							str = $u.hasContent(num) && (values[pp] === 'cost' || values[pp] === 'upkeep' || values[pp] === 'hourly') ? "$" + num.SI() : num.addCommas();
-						}
-
-						row += caap.makeTd({
-							text: str,
-							color: '',
-							id: '',
-							title: ''
-						});
-					}
-
-					body += caap.makeTr(row);
-				}
-
-				$j("#caap_Town_Stats", caap.caapTopObject).html(
-				$j(caap.makeTable('Town', head, body)).dataTable({
-					"bAutoWidth": false,
-					"bFilter": false,
-					"bJQueryUI": false,
-					"bInfo": false,
-					"bLengthChange": false,
-					"bPaginate": false,
-					"bProcessing": false,
-					"bStateSave": true,
-					"bSortClasses": false
-				}));
-
-				session.setItem("townDashUpdate", false);
-            }
-
-            return true;
-        } catch (err) {
-            con.error("ERROR in town.dashboard: " + err);
-            return false;
-        }
-    };
+	town.dashboard = {
+		name: 'Items',
+		inst: 'Display information about items and solders',
+		records: 'town',
+		tableEntries: [
+			{name: 'Name'},
+			{name: 'Type'},
+			{name: 'Own', value: 'owned'},
+			{name: 'Atk'},
+			{name: 'Def'},
+			{name: 'API'},
+			{name: 'DPI'},
+			{name: 'MPI'},
+			{name: 'Cost', format: '$SI'},
+			{name: 'Upkeep', format: '$SI'},
+			{name: 'Hourly', format: '$SI'}
+		]
+	};
 
 }());


### PR DESCRIPTION
Dashboards
Full conversion over to worker style, increasing speed, standardizing control, and reducing over 1000 lines of code
Improve responsiveness to changes

Battle
Change target selection to never attack someone you have lost to before
Add Festival Rank to dashboard
Fix scoring to pick appropriate targets for Demi/Zin/Misa
Fix battling so it happens as part of leveling up to burn up extra stamina points
Fix endless hitting of a conquest recon target that is hiding

Monster
Break apart player name and monster name on dashboard to enable sorting by monster
Add next siege button click to dashboard (1, 50, 250)
Add URL as right click copyable to monster name on dashboard and remove "LINK" entry
Fix issue with different page name causing duplicate entries of Conquest monsters

Finder
Add back monster general for Finder attacks
Add Finder conditions to dashboard (i) marks

GB
Add mirror for Mirror Image defense action
Change dashboard dropdown for opponent/your guild selection to buttons

Generals
Simplify dashboard to show general attack/defense and effective API and DPI
Fix loadout reset rebuilding to cover old type generals like Zarevok and Sano

Other
Added ability for SetDisplay to set DOM elements by class
Add toggle to disable town reviews -- item inventory uses local storage and have no effect on CAAP aside from the dashboard