### PR TITLE
Questing fixes

### DIFF
--- a/Chrome/unpacked/js/worker_conquest.js
+++ b/Chrome/unpacked/js/worker_conquest.js
@@ -62,7 +62,7 @@ schedule,state,general,session,monster */
 					con.warn('Conquest: unable to conquest tokens', text);
 				}
 				
-				if (stats.rank.conquestLevel < 100 && !caap.bulkRegex(text, /Points to Next \w+: (\d+)/, stats, ['conquest.dif'])) {
+				if (stats.rank.conquestLevel < 100 && !caap.bulkRegex(text, /Points to Next Level: (\d+)/, stats, ['conquest.dif'])) {
 					con.warn('Conquest: unable to conquest tokens to level', text);
 				}
 				
@@ -188,13 +188,14 @@ schedule,state,general,session,monster */
 				return false;
 			}
 			
-            var result = false, 
+            var result = false,
+				collectTime = false,
 				message = [], 
 				pts = 0,
 				when,
 				vals = [0, 1000, 3000];
 		
-			['Conqueror','Guardian','Engineer'].every( function(category) {
+			collectTime = ['Conqueror','Guardian','Engineer'].every( function(category) {
 				when = config.getItem('When' + category, 'Never');
 				if (when == 'Never') {
 					return true;
@@ -215,7 +216,7 @@ schedule,state,general,session,monster */
 				}
 			});
 			
-			if (message.length || (stats.conquest.Conqueror <= 150 && stats.conquest.Guardian <= 150 && stats.conquest.Engineer == 0)) {
+			if (collectTime && (message.length || (stats.conquest.Conqueror <= 150 && stats.conquest.Guardian <= 150 && stats.conquest.Engineer == 0))) {
 				result = conquest.hunterCombos('link');
 				if (result) {
 					caap.navigate2("ajax:" + result + '&action=collectReward');
@@ -228,7 +229,7 @@ schedule,state,general,session,monster */
 				}
 			}
 				
-			if (message.length) {
+			if (collectTime && message.length) {
 				result = caap.navigate3('guildv2_conquest_command.php?tier=3','conquest_path_shop.php?action=report_collect&ajax=1');
 				if (result) {
 					if (result == 'done') {

--- a/Chrome/unpacked/js/worker_monster.js
+++ b/Chrome/unpacked/js/worker_monster.js
@@ -1087,7 +1087,7 @@ config,con,gm,schedule,state,general,session,conquest,monster:true */
 					}
 
 				} else if (cM.state == 'Done') {
-					if (cM.lpage == "player_monster_list" && (/:clear\b/.test(cM.conditions) || (!/:!clear\b/.test(cM.conditions) && config.getItem('clearCompleteMonsters', false)))) {
+					if (cM.lpage == "player_monster_list" && !cM.link.match(/mpool=2/) && (/:clear\b/.test(cM.conditions) || (!/:!clear\b/.test(cM.conditions) && config.getItem('clearCompleteMonsters', false)))) {
 						link = link.replace("battle_monster.php?casuser=", "player_monster_list.php?remove_list=").concat("&monster_filter=1");
 						message = 'Clearing ';
 						monster.deleteRecord(cM.link);

--- a/Chrome/unpacked/js/worker_quest.js
+++ b/Chrome/unpacked/js/worker_quest.js
@@ -298,6 +298,10 @@ gb,essence,gift,chores */
 					}
 				};
 				
+			if (questFor == 'Manual') {
+				return;
+			}
+			
 			validQuests = quest.records.filter( function(q) {
 				return stats.gold.total >= q.cost && q.influence < 100 &&
 					(questFor != 'Advancement' || !opening || questLand.getRecordVal(q.land, 'status') == 'Opening');


### PR DESCRIPTION
Fix for Conquest Battle not using all tokens to level up when able to.
Fix for conquest collect collecting when only one condition is met
instead of all configured conditions
Fix for attempted clearing of player-summoned serpents or dragons which
cannot be cleared
Fix for quest manual setting being overwritten at load and after
unpaused