### PR TITLE
Quest fixes

### DIFF
--- a/Chrome/unpacked/js/caap_navigation.js
+++ b/Chrome/unpacked/js/caap_navigation.js
@@ -320,7 +320,8 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 							s += 1;
 							break;
 						}
-					} else if (action == 'ajax') {						if (session.getItem('clickUrl', '').replace(/.*\//,'') !== text) {
+					} else if (action == 'ajax') {
+						if (session.getItem('clickUrl', '').replace(/.*\//,'') !== text) {
 							result = caap.ajaxLink(text,2000);
 							con.log(2, 'Navigate2: Go to ajax link '+ text, result, jq, step, path, s);
 							return s == lastStep ? 'done' : caap.navigate2RepeatCheck(true, path, s);


### PR DESCRIPTION
Fix for reading status of quest lands
Fix to read influence level of not fully opened lands
Add average energy for group of quests to dashboard
Change to prioritize quests with low group energy requirements instead
of low individual quest energy
Fix for advancement to do low energy instead of high energy quests
Fix to avoid excavation quests unless manually set