### PR TITLE
Stance monsters and Hunter point collect

### DIFF
--- a/Chrome/unpacked/js/caap_base.js
+++ b/Chrome/unpacked/js/caap_base.js
@@ -4010,7 +4010,7 @@ gb,essence,gift,chores,quest */
 	caap.gameDay = function(offsetSeconds, time) {
 		time = new Date($u.setContent(time, Date.now()));
 		offsetSeconds = $u.setContent(offsetSeconds, 0); 	// Need to adjust from 7 to 8 when daylight savings time changes in winter
-		return caap.weekdays[new Date(time.getTime() + ((time.getTimezoneOffset() / 60 - 8) * 3600 + offsetSeconds) * 1000).getDay()];
+		return caap.weekdays[new Date(time.getTime() + ((time.getTimezoneOffset() / 60 - 7) * 3600 + offsetSeconds) * 1000).getDay()];
 	};
 	
     caap.getStatusNumbers = function (text, record) {
@@ -4236,8 +4236,28 @@ gb,essence,gift,chores,quest */
 			if (result) {
 				return true;
 			}
+			
+			if (stats.energy.num >= caap.maxStatCheck('energy')) {
+				result = caap.passThrough(quest.worker());
+				if (result) {
+					return result;
+				}
+			}
 
-			return stats.energy.num >= caap.maxStatCheck('energy') ? quest.worker() : false;
+			if (stats.stamina.num >= caap.maxStatCheck('stamina')) {
+				result = caap.passThrough(battle.worker());
+				if (result) {
+					return result;
+				}
+				result = caap.passThrough(monster.worker());
+				if (result) {
+					return result;
+				}
+				result = caap.passThrough(battle.monsterWait());
+				if (result) {
+					return result;
+				}
+			}
         } catch (err) {
             con.error("ERROR in maxStatsCheck: " + err.stack);
             return undefined;

--- a/Chrome/unpacked/js/caap_navigation.js
+++ b/Chrome/unpacked/js/caap_navigation.js
@@ -432,12 +432,6 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 			}
 			
 			options = $u.setContent(options, {});
-			if (caap.page != toPage.replace(/\.php.*/, '') || !caap.clickUrl.hasIndexOf(toPage)) {
-				caap.ajaxLink(toPage);
-				con.log(2, 'Navigate3: Go to ajax link '+ toPage, caap.page, caap.clickUrl);
-				return true;
-			}
-			
 			if (!$u.setContent(options.check, true) || $u.hasContent($j('[href*="' + click + '"]'))) {
 				caap.ajaxLink(click);
 				con.log(2, 'Navigate3: Clicking link '+ click);
@@ -461,6 +455,13 @@ regexp: true, eqeq: true, newcap: true, forin: false */
 				con.log(2, 'Navigate3: Clicking form link '+ click);
 				return 'done';
 			}
+
+			if (caap.page != toPage.replace(/\.php.*/, '') || !caap.clickUrl.hasIndexOf(toPage)) {
+				caap.ajaxLink(toPage);
+				con.log(2, 'Navigate3: Go to ajax link '+ toPage, caap.page, caap.clickUrl);
+				return true;
+			}
+			
 			con.warn('Navigate3: ' + click + ' link type not found on page ' + toPage);
 			caap.bad3.push(toPage + ':' + click);
 			caap.scrapeLinks();

--- a/Chrome/unpacked/js/head.js
+++ b/Chrome/unpacked/js/head.js
@@ -3,7 +3,7 @@
 // @namespace      caap
 // @description    Auto player for Castle Age
 // @version        141.0.0
-// @dev			287
+// @dev    287
 // @license        GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // ==/UserScript==
 
@@ -102,6 +102,12 @@ Array.prototype.sum = function() {
 	return this.reduce(function(a,b) {
 		return a+b;
 	}, 0);
+};
+
+Array.prototype.sumsList = function() {
+	return this.map( function(a) {
+		return a.sum();
+	});
 };
 
 Array.prototype.removeFromList = function(v) {

--- a/Chrome/unpacked/js/worker_battle.js
+++ b/Chrome/unpacked/js/worker_battle.js
@@ -339,7 +339,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 			battle.RaidDuel = $j.extend({}, battle.Duel, battle.RaidDuel);
 
 			battle.records = battle.records.filter( function(r) {
-				foughtRecently = !schedule.since(r.wonTime, 4 * 7 * 24 * 3600) || !schedule.since(r.lostTime,  4 * 7 * 24 * 3600);
+				foughtRecently = !schedule.since(r.wonTime, 2 * 7 * 24 * 3600) || !schedule.since(r.lostTime,  3 * 7 * 24 * 3600);
 				newbie = !schedule.since(r.deadTime, 24 * 3600);
 				if (foughtRecently || newbie) {
 					return true;
@@ -459,7 +459,7 @@ schedule,gifting,state,army, general,session,monster,guild_monster */
 	            staminaReq = 0,
                 whenMonster = config.getItem('WhenMonster', 'Never'),
 				whenBattle = config.getItem(w.when, 'Never'),
-	            targetMonster = state.getItem('targetFrombattle_monster', ''),
+	            targetMonster = state.getItem('targetFromMonster', ''),
                 monsterObject = $u.hasContent(targetMonster) ? monster.getRecord(targetMonster) : {},
 				demisLeft = battle.demisPointsToDo('left'),
 				battleOrOverride = 'Battle';

--- a/Chrome/unpacked/js/worker_feed.js
+++ b/Chrome/unpacked/js/worker_feed.js
@@ -277,6 +277,9 @@ chores,town,general,session,monster:true */
 					} else {
 						link += ",clickimg:battle_enter_battle.gif";
 					}
+				} else {
+					link += tR.targetPart > 0 ? (",clickjq:#app_body #monster_target_" +
+				tR.targetPart + " img[src*='multi_selectbtn.jpg'],jq:#app_body #expanded_monster_target_" + tR.targetPart + ":visible") : ''
 				}
 				
 				if (general.Select('MonsterGeneral')) {

--- a/Chrome/unpacked/js/worker_gb.js
+++ b/Chrome/unpacked/js/worker_gb.js
@@ -881,7 +881,7 @@ schedule,state,general,session,battle:true */
 								case '10v10' :		tf = gf.name.toLowerCase() == key;									break;
 								case 'easy' :		tf = fR.easy;														break;
 								case 'easyc' :		tf = fR.easy && mR.mclass == 'cleric';								break;
-								case mR.target_id.toString() : tf = true;															break;
+								case mR.target_id.toString() : tf = true;												break;
 								case 'simtis' :		tf = fR.simtis;														break;
 								case 'unstunned' :	tf = mR.healthNum > 200;											break;
 								case 'meshout' :	tf = fR.me.shout;													break;
@@ -907,8 +907,8 @@ schedule,state,general,session,battle:true */
 
 							args = text.match(new RegExp('(!?)' + key + ':(\\*?)(-?)([\\.\\d]+)'));
 							
-							// Deliberate avoidance of "tf !==" to catch 0 or undefined, etc.
 							notArg = (args[1] == '!');
+							tf = !(!tf);
 							if (args && args.length == 5 && tf !== notArg) { 
 								normal[args[2] == '*' ? 't' : 'p'] += args[3] == '-' ? -args[4].parseFloat() : args[4].parseFloat();
 							}

--- a/Chrome/unpacked/js/worker_loe.js
+++ b/Chrome/unpacked/js/worker_loe.js
@@ -86,6 +86,11 @@ schedule,state,general,session,battle:true */
 				which = guild_id == stats.guild.id ? 'your' : 'enemy';
 				fR = gb.getRecord('loe');
 				session.setItem('gbWhich', fR.label);
+				if (resultsText.regex(/Your guild is too (\w+) level to engage in this battle/)) {
+					fR.state = 'No battle';
+					gb.setRecord(fR);
+					return;
+				}
 				battle.readWinLoss(resultsText, gb.winLoss);
 				
 				towerDivs = which == 'enemy' ? $j('#hover_tab_1_1').closest('.tower_tab').find('div[onmouseover*="hover_tab_1_"]') :
@@ -174,12 +179,11 @@ schedule,state,general,session,battle:true */
 				stun = 'unstunned',
 				mess = 'conquest_mess',
 				stateMsg = '',
-				path,
 				t = {score : 0},
 				result = false,
 				seal = fR[which].seal ? 'seal' : 'normal',
-				doLand = which == 'your' && stats.conquest.Guardian >= whenGuard ? false : isloe ?
-					whenLoE != 'Never' && (whenLoE != 'Blue Crystals' || loe.blueDay()) : fR.state == 'Active';
+				doLand = (fR.state == 'Active' || (which == 'enemy' && isloe)) && (which != 'your' || stats.conquest.Guardian < whenGuard) 
+					&& (!isloe || (whenLoE != 'Never' && (whenLoE != 'Blue Crystals' || loe.blueDay())));
 				
 			if (!stats.guildTokens.num || !doLand) {
 				return false;
@@ -222,12 +226,12 @@ schedule,state,general,session,battle:true */
 			
 			caap.setDivContent(mess, stateMsg + t.attack + ' on ' + t.team + ' T' + t.tower + ' ' + t.name);
 			con.log(2,  stateMsg + t.attack + ' on ' + t.team + ' T' + t.tower + ' ' + t.name, t);
-			//n = t.tower.toString().replace(/.*:/,'');
-			//path = ',clickjq:div[onclick^="towerTabClick(' + "'" + n + "'" + ')"]:visible,jq:#tower_' +
-			//	n + ':visible,clickjq:.action_panel_' + t.id + ' input[src*="' + t.attack + '.jpg"]';
-			path = isloe ? ',clickjq:.action_panel_' + t.id + ' input[src*="' + t.attack + '.jpg"]' :
-				',clickjq:#special_defense_1_' + t.id + ' input[src*="' + t.attack + '.gif"]';
-			result = caap.navigate2(t.general + ',' + gb.makePath(gf, t.team, t.tower) + path);
+
+			//path = isloe ? ',clickjq:.action_panel_' + t.id + ' input[src*="' + t.attack + '.jpg"]' :
+			//	',clickjq:#special_defense_1_' + t.id + ' input[src*="' + t.attack + '.gif"]';
+			
+			result = caap.navigate2(t.general + ',' + gb.makePath(gf, t.team, t.tower) + ',clickjq:.action_panel_' + t.id
+				+ ' input[src*="' + t.attack + '.jpg"]');
 			if (result == 'fail') {
 				con.warn(stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack + ', reloading page', general.current, general.loadout);
 				caap.setDivContent(mess, stateMsg + t.attack + ' failed on ' + t.team + ' T' + t.tower + ' ' + t.name + ' Check ' + general.current + ' has ' + t.attack);

--- a/Chrome/unpacked/js/worker_lom.js
+++ b/Chrome/unpacked/js/worker_lom.js
@@ -131,7 +131,7 @@ schedule,state,general,session,battle:true */
 					
 				} else {
 					
-					$j('div[id^="special_defense_button"] form input[type="image"]').each( function() {
+					$j('div[id^="special_defense_button"] form input[type="image"], div[id^="action_panel"] form input[type="image"]').each( function() {
 						powers.addToList($j(this).attr('src').regex(/.*\/(\w+\.\w+)/));
 					});
 					

--- a/Chrome/unpacked/js/worker_quest.js
+++ b/Chrome/unpacked/js/worker_quest.js
@@ -49,6 +49,9 @@ gb,essence,gift,chores */
         try {
 			var lR = {};
 			
+			// in results text The excavation quest timer has expired. Collect your reward now!
+			//quests.php?excavation=10010&do_collect=10010&bqh=414986b7dd2bd6e69a24adc401aa2023&ajax=1
+			
 			switch (page) {
 			case 'symbolquests' :
 				lR = questLand.getRecord('symbolquests');

--- a/Chrome/unpacked/js/worker_stats.js
+++ b/Chrome/unpacked/js/worker_stats.js
@@ -130,6 +130,7 @@ gm,hiddenVar,battle,general */
 				Engineer: 0,
 				dif : 0,
 				collectOk: true,
+				checkPoints : false
 			},
 			LoMland: -1,
 			other: {


### PR DESCRIPTION
General
Update daylight savings time
Add ability to burn stamina with monsters or battle when at max

Quests
Fix navigation so able to do same quest repeatedly without reloading
page between each quest

Battle
Change memory settings to remember wins for 2 weeks and losses for three
weeks
Fix settings that prevented doing battle due to old monster setting

Conquest
Fix saving up tokens for toons that are at Conquest level 100
Improve calculations for :hunt option to save up points to desired
Conquest collect amount
Fix path for new LoM defensive path
Fix timing for doing LoM defense

Finder
Enable joining monsters that have the primary part at 0% health

GB
Fix problem with active/inactive targetting

Monster
Fix dead monsters not being replaced with live monster that fill the
same slot
Add reset for spent stamina/energy when new monster summoned in same
slot
Add new stance type monster targetting
Spread out stance type monster targetting between targets to maximize
siege value
Add hourly update for newly killed monsters instead of waiting 24 hours